### PR TITLE
[7.0] [REF] account_voucher_no_auto_line [needs review]

### DIFF
--- a/account_vat_on_payment/account_voucher.py
+++ b/account_vat_on_payment/account_voucher.py
@@ -41,8 +41,8 @@ class account_voucher(orm.Model):
                 if line.amount:
                     valid_lines += 1
                     if (
-                        line.move_line_id and line.move_line_id.invoice
-                        and line.move_line_id.invoice.vat_on_payment
+                        line.move_line_id and line.move_line_id.invoice and
+                        line.move_line_id.invoice.vat_on_payment
                     ):
                         vat_on_p += 1
             if vat_on_p and vat_on_p != valid_lines:
@@ -59,8 +59,8 @@ class account_voucher(orm.Model):
         # the paid amount
         allocated_amount = allocated + write_off
         if (
-            voucher.exclude_write_off
-            and voucher.payment_option == 'with_writeoff'
+            voucher.exclude_write_off and
+            voucher.payment_option == 'with_writeoff'
         ):
             # avoid including write-off if set in voucher.
             # That means: use the invoice's total
@@ -80,8 +80,7 @@ class account_voucher(orm.Model):
             context=context)
         new_line_amount = currency_obj.round(
             cr, uid, voucher.company_id.currency_id,
-            (allocated_amount / amounts_by_invoice[invoice.id]['total'])
-            *
+            (allocated_amount / amounts_by_invoice[invoice.id]['total']) *
             (inv_move_line.credit or inv_move_line.debit)
         )
         return new_line_amount
@@ -93,8 +92,8 @@ class account_voucher(orm.Model):
         currency_obj = self.pool.get('res.currency')
         new_line_amount_curr = False
         if (
-            amounts_by_invoice[invoice.id].get('allocated_currency')
-            and amounts_by_invoice[invoice.id].get('foreign_currency_id')
+            amounts_by_invoice[invoice.id].get('allocated_currency') and
+            amounts_by_invoice[invoice.id].get('foreign_currency_id')
         ):
             for_curr = currency_obj.browse(
                 cr, uid, amounts_by_invoice[invoice.id]['foreign_currency_id'],
@@ -109,9 +108,7 @@ class account_voucher(orm.Model):
                 (
                     allocated_amount /
                     amounts_by_invoice[invoice.id]['total_currency']
-                )
-                *
-                (inv_move_line.amount_currency)
+                ) * (inv_move_line.amount_currency)
             )
         return new_line_amount_curr
 
@@ -133,8 +130,8 @@ class account_voucher(orm.Model):
             'debit': (inv_move_line.debit and new_line_amount or 0.0),
             'type': 'real',
             'partner_id': (
-                inv_move_line.partner_id
-                and inv_move_line.partner_id.id or False)
+                inv_move_line.partner_id and
+                inv_move_line.partner_id.id or False)
         }
         if new_line_amount_curr:
             vals['amount_currency'] = new_line_amount_curr
@@ -163,15 +160,15 @@ class account_voucher(orm.Model):
             'name': inv_move_line.name,
             'account_id': inv_move_line.account_id.id,
             'credit': (
-                inv_move_line.debit
-                and new_line_amount or 0.0),
+                inv_move_line.debit and
+                new_line_amount or 0.0),
             'debit': (
-                inv_move_line.credit
-                and new_line_amount or 0.0),
+                inv_move_line.credit and
+                new_line_amount or 0.0),
             'type': 'shadow',
             'partner_id': (
-                inv_move_line.partner_id
-                and inv_move_line.partner_id.id or False)
+                inv_move_line.partner_id and
+                inv_move_line.partner_id.id or False)
         }
         if inv_move_line.tax_code_id:
             vals[
@@ -201,10 +198,10 @@ class account_voucher(orm.Model):
                 # want to compute the tax including write-off,
                 # write-off move line must stay on the real move
                 if not (
-                    voucher.exclude_write_off
-                    and voucher.payment_option == 'with_writeoff'
-                    and line.account_id.id
-                        == voucher.writeoff_acc_id.id
+                    voucher.exclude_write_off and
+                    voucher.payment_option == 'with_writeoff' and
+                    line.account_id.id ==
+                    voucher.writeoff_acc_id.id
                 ):
                     line.write({
                         'move_id': shadow_move_id,
@@ -212,8 +209,8 @@ class account_voucher(orm.Model):
                 # this will allow user to see the real entry from
                 # invoice payment tab
                 if (
-                    line.account_id.type == 'receivable'
-                    or line.account_id.type == 'payable'
+                    line.account_id.type == 'receivable' or
+                    line.account_id.type == 'payable'
                 ):
                     line.write({
                         'real_payment_move_id': voucher.move_id.id,
@@ -240,8 +237,8 @@ class account_voucher(orm.Model):
             invoice = inv_pool.browse(cr, uid, inv_id, context)
             for inv_move_line in invoice.move_id.line_id:
                 if (
-                    inv_move_line.account_id.type != 'receivable'
-                    and inv_move_line.account_id.type != 'payable'
+                    inv_move_line.account_id.type != 'receivable' and
+                    inv_move_line.account_id.type != 'payable'
                 ):
                     new_line_amount = self._compute_new_line_amount(
                         cr, uid, voucher, inv_move_line,

--- a/account_vat_on_payment/test/account_invoice_1.yml
+++ b/account_vat_on_payment/test/account_invoice_1.yml
@@ -81,6 +81,13 @@
     partner_id: base.res_partner_3
     amount: 120
 -
+  I check the full reconcile box
+-
+  !python {model: account.voucher}: |
+    voucher = self.browse(cr, uid, ref('account_voucher_1'), context=context)
+    voucher_line = voucher.line_cr_ids[0]
+    voucher_line.write({'reconcile': True, 'amount': 120})
+-
   I confirm the voucher
 -
   !workflow {model: account.voucher, action: proforma_voucher, ref: account_voucher_1}

--- a/account_vat_on_payment/test/account_invoice_2.yml
+++ b/account_vat_on_payment/test/account_invoice_2.yml
@@ -29,6 +29,13 @@
     partner_id: base.res_partner_3
     amount: 50
 -
+  I check the full reconcile box
+-
+  !python {model: account.voucher}: |
+    voucher = self.browse(cr, uid, ref('account_voucher_2'), context=context)
+    voucher_line = voucher.line_cr_ids[0]
+    voucher_line.write({'reconcile': True, 'amount': 50})
+-
   I confirm the voucher
 -
   !workflow {model: account.voucher, action: proforma_voucher, ref: account_voucher_2}
@@ -65,6 +72,13 @@
   !record {model: account.voucher, id: account_voucher_2_b, view: account_voucher.view_vendor_receipt_form}:
     partner_id: base.res_partner_3
     amount: 70
+-
+  I check the full reconcile box
+-
+  !python {model: account.voucher}: |
+    voucher = self.browse(cr, uid, ref('account_voucher_2_b'), context=context)
+    voucher_line = voucher.line_cr_ids[0]
+    voucher_line.write({'reconcile': True, 'amount': 70})
 -
   I confirm the voucher
 -

--- a/account_vat_on_payment/test/account_invoice_3.yml
+++ b/account_vat_on_payment/test/account_invoice_3.yml
@@ -49,6 +49,13 @@
     partner_id: base.res_partner_3
     amount: 100
 -
+  I check the full reconcile box
+-
+  !python {model: account.voucher}: |
+    voucher = self.browse(cr, uid, ref('account_voucher_3_a'), context=context)
+    voucher_line = voucher.line_cr_ids[0]
+    voucher_line.write({'reconcile': True, 'amount': 100})
+-
   I confirm the voucher
 -
   !workflow {model: account.voucher, action: proforma_voucher, ref: account_voucher_3_a}
@@ -86,6 +93,13 @@
   !record {model: account.voucher, id: account_voucher_3_b, view: account_voucher.view_vendor_receipt_form}:
     partner_id: base.res_partner_3
     amount: 130
+-
+  I check the full reconcile box
+-
+  !python {model: account.voucher}: |
+    voucher = self.browse(cr, uid, ref('account_voucher_3_b'), context=context)
+    voucher_line = voucher.line_cr_ids[0]
+    voucher_line.write({'reconcile': True, 'amount': 130})
 -
   I confirm the voucher
 -

--- a/account_vat_on_payment/test/account_invoice_5.yml
+++ b/account_vat_on_payment/test/account_invoice_5.yml
@@ -87,6 +87,13 @@
     journal_id: account.bank_journal_usd
     date: !eval "'%s-08-15' %(datetime.now().year)"
 -
+  I check the full reconcile box
+-
+  !python {model: account.voucher}: |
+    voucher = self.browse(cr, uid, ref('account_voucher_5_a'), context=context)
+    voucher_line = voucher.line_cr_ids[0]
+    voucher_line.write({'reconcile': True, 'amount': 120})
+-
   I confirm the voucher
 -
   !workflow {model: account.voucher, action: proforma_voucher, ref: account_voucher_5_a}

--- a/account_voucher_no_auto_lines/__init__.py
+++ b/account_voucher_no_auto_lines/__init__.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+###############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    This module copyright (C) 2014 Savoir-faire Linux
+#    (<http://www.savoirfairelinux.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+###############################################################################
+
+from . import account_voucher

--- a/account_voucher_no_auto_lines/__openerp__.py
+++ b/account_voucher_no_auto_lines/__openerp__.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+###############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    This module copyright (C) 2014 Savoir-faire Linux
+#    (<http://www.savoirfairelinux.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+###############################################################################
+
+{
+    'name': 'Account Voucher No Auto Lines',
+    'version': '1.0',
+    'category': 'Accounting & Finance',
+    'description': """
+Account Voucher No Auto Lines
+=============================
+
+This module disables the fill of the amount column of voucher lines
+when we select the partner.
+
+Contributors
+------------
+* Joao Alfredo Gama Batista (joao.gama@savoirfairelinux.com)
+    """,
+    'author': 'Savoir-faire Linux',
+    'website': 'http://www.savoirfairelinux.com',
+    'depends': [
+        'account_voucher',
+    ],
+    'data': [],
+    'installable': True,
+    'auto_install': False,
+}

--- a/account_voucher_no_auto_lines/__openerp__.py
+++ b/account_voucher_no_auto_lines/__openerp__.py
@@ -28,8 +28,9 @@
 Account Voucher No Auto Lines
 =============================
 
-This module disables the fill of the amount column of voucher lines
-when we select the partner.
+This module allows users to select manually the lines to be payed by
+the voucher. The voucher will no longer try to match the credits/debits
+with the total amount.
 
 Contributors
 ------------
@@ -40,7 +41,7 @@ Contributors
     'depends': [
         'account_voucher',
     ],
-    'data': [],
+    'data': ['account_voucher_view.xml'],
     'installable': True,
     'auto_install': False,
 }

--- a/account_voucher_no_auto_lines/account_voucher.py
+++ b/account_voucher_no_auto_lines/account_voucher.py
@@ -110,7 +110,9 @@ class account_voucher(orm.Model):
             cr, uid, ids, *args, **kwargs)
 
         # Check that the method was called from the account payment view
-        if context.get('allow_auto_lines', False):
+        if context.get('allow_auto_lines', False) or \
+                context.get('active_model', False) == 'account.invoice':
+            print context
             return res
 
         if 'value' in res and 'line_cr_ids' in res['value']:

--- a/account_voucher_no_auto_lines/account_voucher.py
+++ b/account_voucher_no_auto_lines/account_voucher.py
@@ -102,7 +102,7 @@ class account_voucher(orm.Model):
 
     def onchange_partner_id(self, cr, uid, ids, *args, **kwargs):
 
-        context = args[-1]
+        context = kwargs.get('context', False) or args[-1]
 
         line_dr_ids, line_cr_ids = copy_lines(context)
 
@@ -127,7 +127,7 @@ class account_voucher(orm.Model):
 
     def onchange_journal(self, cr, uid, ids, *args, **kwargs):
 
-        context = args[-1]
+        context = kwargs.get('context', False) or args[-1]
 
         line_dr_ids, line_cr_ids = copy_lines(context)
 
@@ -144,7 +144,7 @@ class account_voucher(orm.Model):
 
     def onchange_amount(self, cr, uid, ids, *args, **kwargs):
 
-        context = args[-1]
+        context = kwargs.get('context', False) or args[-1]
 
         line_dr_ids, line_cr_ids = copy_lines(context)
 

--- a/account_voucher_no_auto_lines/account_voucher.py
+++ b/account_voucher_no_auto_lines/account_voucher.py
@@ -32,8 +32,8 @@ def copy_lines(context=None):
             'reconcile': line[2]['reconcile']
         }
         for line in context.get('line_dr_ids', [])
-        if line[2] and line[2]['amount']
-        and line[2].get('type', False) == 'dr'
+        if line[2] and line[2]['amount'] and
+        line[2].get('type', False) == 'dr'
     }
 
     line_cr_ids = {
@@ -43,8 +43,8 @@ def copy_lines(context=None):
             'reconcile': line[2]['reconcile']
         }
         for line in context.get('line_cr_ids', [])
-        if line[2] and line[2]['amount']
-        and line[2].get('type', False) == 'cr'
+        if line[2] and line[2]['amount'] and
+        line[2].get('type', False) == 'cr'
     }
 
     return line_dr_ids, line_cr_ids

--- a/account_voucher_no_auto_lines/account_voucher.py
+++ b/account_voucher_no_auto_lines/account_voucher.py
@@ -98,7 +98,7 @@ class account_voucher(orm.Model):
         voucher.line deletes references to old lines and replace them
         by "auto lines"... 
         """
-        context = kwargs['context']
+        context = kwargs.get('context', {})
 
         line_pool = self.pool['account.voucher.line']
         line_cr_ids, line_dr_ids  = copy_lines(cr, uid, ids, line_pool, context)

--- a/account_voucher_no_auto_lines/account_voucher.py
+++ b/account_voucher_no_auto_lines/account_voucher.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+###############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    This module copyright (C) 2014 Savoir-faire Linux
+#    (<http://www.savoirfairelinux.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+###############################################################################
+
+from openerp.osv import orm, fields
+
+
+class account_voucher(orm.Model):
+
+    _inherit = 'account.voucher'
+
+    def onchange_amount(self, *args, **kwargs):
+
+        res = super(account_voucher, self).onchange_amount(*args, **kwargs)
+
+        if 'context' in kwargs and 'type' in kwargs['context']:
+            if kwargs['context']['type'] == 'receipt':
+                lines = res['value']['line_cr_ids']
+            elif kwargs['context']['type'] == 'payment':
+                lines = res['value']['line_dr_ids']
+
+            for line in lines:
+                line['amount'] = 0.0
+
+        return res

--- a/account_voucher_no_auto_lines/account_voucher.py
+++ b/account_voucher_no_auto_lines/account_voucher.py
@@ -144,8 +144,6 @@ class account_voucher(orm.Model):
 
         context = kwargs.get('context', False) or args[-1]
 
-        line_dr_ids, line_cr_ids = copy_lines(context)
-
         res = super(account_voucher, self).onchange_amount(
             cr, uid, ids, *args, **kwargs)
 
@@ -153,6 +151,10 @@ class account_voucher(orm.Model):
         if context.get('allow_auto_lines', False):
             return res
 
-        update_lines(res, line_dr_ids, line_cr_ids)
+        if res.get('value', False):
+            if res['value'].get('line_cr_ids', False):
+                del res['value']['line_cr_ids']
+            if res['value'].get('line_dr_ids', False):
+                del res['value']['line_dr_ids']
 
         return res

--- a/account_voucher_no_auto_lines/account_voucher.py
+++ b/account_voucher_no_auto_lines/account_voucher.py
@@ -20,24 +20,39 @@
 #
 ###############################################################################
 
-from openerp.osv import orm, fields
+from openerp.osv import orm
 
 
 class account_voucher(orm.Model):
 
     _inherit = 'account.voucher'
 
-    def onchange_amount(self, *args, **kwargs):
+    def onchange_partner_id(self, cr, uid, ids, *args, **kwargs):
 
-        res = super(account_voucher, self).onchange_amount(*args, **kwargs)
+        res = super(account_voucher, self).onchange_partner_id(
+            cr, uid, ids, *args, **kwargs)
 
-        if 'context' in kwargs and 'type' in kwargs['context']:
-            if kwargs['context']['type'] == 'receipt':
-                lines = res['value']['line_cr_ids']
-            elif kwargs['context']['type'] == 'payment':
-                lines = res['value']['line_dr_ids']
-
-            for line in lines:
+        if 'value' in res and 'line_cr_ids' in res['value']:
+            for line in res['value']['line_cr_ids']:
                 line['amount'] = 0.0
+                line['reconcile'] = False
+
+        if 'value' in res and 'line_dr_ids' in res['value']:
+            for line in res['value']['line_dr_ids']:
+                line['amount'] = 0.0
+                line['reconcile'] = False
+
+        return res
+
+    def onchange_amount(self, cr, uid, ids, *args, **kwargs):
+
+        res = super(account_voucher, self).onchange_amount(
+            cr, uid, ids, *args, **kwargs)
+
+        if 'context' in kwargs and 'line_cr_ids' in kwargs['context']:
+            res['value']['line_cr_ids'] = kwargs['context']['line_cr_ids']
+
+        if 'context' in kwargs and 'line_dr_ids' in kwargs['context']:
+            res['value']['line_dr_ids'] = kwargs['context']['line_dr_ids']
 
         return res

--- a/account_voucher_no_auto_lines/account_voucher.py
+++ b/account_voucher_no_auto_lines/account_voucher.py
@@ -90,17 +90,13 @@ class account_voucher(orm.Model):
         by "auto lines"... 
         """
 
-        context = kwargs.get('context', None)
-
-        if context:
-            line_pool = self.pool['account.voucher.line']
-            line_cr_ids, line_dr_ids  = copy_lines(cr, uid, ids, line_pool)
+        line_pool = self.pool['account.voucher.line']
+        line_cr_ids, line_dr_ids  = copy_lines(cr, uid, ids, line_pool)
 
         res = super(account_voucher, self).onchange_amount(
             cr, uid, ids, *args, **kwargs)
 
-        if context:
-            res['value']['line_cr_ids'] = line_cr_ids
-            res['value']['line_dr_ids'] = line_dr_ids
+        res['value']['line_cr_ids'] = line_cr_ids
+        res['value']['line_dr_ids'] = line_dr_ids
 
         return res

--- a/account_voucher_no_auto_lines/account_voucher.py
+++ b/account_voucher_no_auto_lines/account_voucher.py
@@ -49,10 +49,14 @@ class account_voucher(orm.Model):
         res = super(account_voucher, self).onchange_amount(
             cr, uid, ids, *args, **kwargs)
 
-        if 'context' in kwargs and 'line_cr_ids' in kwargs['context']:
-            res['value']['line_cr_ids'] = kwargs['context']['line_cr_ids']
+        if 'value' in res and 'line_cr_ids' in res['value']:
+            for line in res['value']['line_cr_ids']:
+                line['amount'] = 0.0
+                line['reconcile'] = False
 
-        if 'context' in kwargs and 'line_dr_ids' in kwargs['context']:
-            res['value']['line_dr_ids'] = kwargs['context']['line_dr_ids']
+        if 'value' in res and 'line_dr_ids' in res['value']:
+            for line in res['value']['line_dr_ids']:
+                line['amount'] = 0.0
+                line['reconcile'] = False
 
         return res

--- a/account_voucher_no_auto_lines/account_voucher.py
+++ b/account_voucher_no_auto_lines/account_voucher.py
@@ -33,13 +33,15 @@ excluded_fields = ['move_line_id',
                    'amount_original',
                    'currency_id']
 
+
 def copy_lines(cr, uid, ids, pool, context):
     if len(ids) == 0:
         return [], []
 
     line_ids = pool.search(cr, uid, [('voucher_id', '=', ids[0])],
                            context=context)
-    saved_lines = pool.read(cr, uid, line_ids, excluded_fields, context=context)
+    saved_lines = pool.read(cr, uid, line_ids, excluded_fields,
+                            context=context)
 
     line_cr_ids = []
     line_dr_ids = []
@@ -90,18 +92,19 @@ class account_voucher(orm.Model):
         Already saved lines should have an id defined
         [6, 455, ...]
 
-        The third value is the data of the line. If the 
+        The third value is the data of the line. If the
         value is False, then it means that the line didn't
         change.
 
         Reference to old ids can't be reused as the base class for
         voucher.line deletes references to old lines and replace them
-        by "auto lines"... 
+        by "auto lines"...
         """
         context = kwargs.get('context', {})
 
         line_pool = self.pool['account.voucher.line']
-        line_cr_ids, line_dr_ids  = copy_lines(cr, uid, ids, line_pool, context)
+        line_cr_ids, line_dr_ids = copy_lines(cr, uid, ids, line_pool,
+                                              context)
 
         res = super(account_voucher, self).onchange_amount(
             cr, uid, ids, *args, **kwargs)

--- a/account_voucher_no_auto_lines/account_voucher.py
+++ b/account_voucher_no_auto_lines/account_voucher.py
@@ -103,16 +103,12 @@ class account_voucher(orm.Model):
     def onchange_partner_id(self, cr, uid, ids, *args, **kwargs):
 
         context = kwargs.get('context', False) or args[-1]
-
-        line_dr_ids, line_cr_ids = copy_lines(context)
-
         res = super(account_voucher, self).onchange_partner_id(
             cr, uid, ids, *args, **kwargs)
 
         # Check that the method was called from the account payment view
         if context.get('allow_auto_lines', False) or \
                 context.get('active_model', False) == 'account.invoice':
-            print context
             return res
 
         if 'value' in res and 'line_cr_ids' in res['value']:

--- a/account_voucher_no_auto_lines/account_voucher_view.xml
+++ b/account_voucher_no_auto_lines/account_voucher_view.xml
@@ -6,9 +6,6 @@
       <field name="model">account.voucher</field>
       <field name="inherit_id" ref="account_voucher.view_vendor_receipt_form"/>
       <field name="arch" type="xml">
-        <field name="amount" position="attributes">
-          <attribute name="context">{'line_cr_ids': line_cr_ids, 'line_dr_ids': line_dr_ids, 'allow_auto_lines': False}</attribute>
-        </field>
         <field name="journal_id" position="attributes">
           <attribute name="context">{'line_cr_ids': line_cr_ids, 'line_dr_ids': line_dr_ids, 'allow_auto_lines': False}</attribute>
         </field>
@@ -20,9 +17,6 @@
       <field name="model">account.voucher</field>
       <field name="inherit_id" ref="account_voucher.view_vendor_payment_form"/>
       <field name="arch" type="xml">
-        <field name="amount" position="attributes">
-          <attribute name="context">{'line_cr_ids': line_cr_ids, 'line_dr_ids': line_dr_ids, 'allow_auto_lines': False}</attribute>
-        </field>
         <field name="journal_id" position="attributes">
           <attribute name="context">{'line_cr_ids': line_cr_ids, 'line_dr_ids': line_dr_ids, 'allow_auto_lines': False}</attribute>
         </field>

--- a/account_voucher_no_auto_lines/account_voucher_view.xml
+++ b/account_voucher_no_auto_lines/account_voucher_view.xml
@@ -40,6 +40,9 @@
         <field name="amount" position="attributes">
           <attribute name="context">{'allow_auto_lines': True}</attribute>
         </field>
+        <field name="partner_id" position="attributes">
+          <attribute name="context">{'allow_auto_lines': True, 'search_default_customer': 1}</attribute>
+        </field>
       </field>
     </record>
 

--- a/account_voucher_no_auto_lines/account_voucher_view.xml
+++ b/account_voucher_no_auto_lines/account_voucher_view.xml
@@ -7,7 +7,10 @@
       <field name="inherit_id" ref="account_voucher.view_vendor_receipt_form"/>
       <field name="arch" type="xml">
         <field name="amount" position="attributes">
-          <attribute name="context">{'line_cr_ids': line_cr_ids, 'line_dr_ids': line_dr_ids}</attribute>
+          <attribute name="context">{'line_cr_ids': line_cr_ids, 'line_dr_ids': line_dr_ids, 'allow_auto_lines': False}</attribute>
+        </field>
+        <field name="journal_id" position="attributes">
+          <attribute name="context">{'line_cr_ids': line_cr_ids, 'line_dr_ids': line_dr_ids, 'allow_auto_lines': False}</attribute>
         </field>
       </field>
     </record>
@@ -18,9 +21,24 @@
       <field name="inherit_id" ref="account_voucher.view_vendor_payment_form"/>
       <field name="arch" type="xml">
         <field name="amount" position="attributes">
-          <attribute name="context">{'line_cr_ids': line_cr_ids, 'line_dr_ids': line_dr_ids}</attribute>
+          <attribute name="context">{'line_cr_ids': line_cr_ids, 'line_dr_ids': line_dr_ids, 'allow_auto_lines': False}</attribute>
+        </field>
+        <field name="journal_id" position="attributes">
+          <attribute name="context">{'line_cr_ids': line_cr_ids, 'line_dr_ids': line_dr_ids, 'allow_auto_lines': False}</attribute>
         </field>
       </field>
     </record>
+
+    <record id="view_vendor_receipt_dialog_form" model="ir.ui.view">
+      <field name="name">view.vendor.payment.form</field>
+      <field name="model">account.voucher</field>
+      <field name="inherit_id" ref="account_voucher.view_vendor_receipt_dialog_form"/>
+      <field name="arch" type="xml">
+        <field name="journal_id" position="attributes">
+          <attribute name="context">{'allow_auto_lines': True}</attribute>
+        </field>
+      </field>
+    </record>
+
   </data>
 </openerp>

--- a/account_voucher_no_auto_lines/account_voucher_view.xml
+++ b/account_voucher_no_auto_lines/account_voucher_view.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+  <data>
+    <record id="view_vendor_receipt_form" model="ir.ui.view">
+      <field name="name">view.vendor.receipt.form</field>
+      <field name="model">account.voucher</field>
+      <field name="inherit_id" ref="account_voucher.view_vendor_receipt_form"/>
+      <field name="arch" type="xml">
+        <field name="amount" position="attributes">
+          <attribute name="context">{'line_cr_ids': line_cr_ids, 'line_dr_ids': line_dr_ids}</attribute>
+        </field>
+      </field>
+    </record>
+
+    <record id="view_vendor_payment_form" model="ir.ui.view">
+      <field name="name">view.vendor.payment.form</field>
+      <field name="model">account.voucher</field>
+      <field name="inherit_id" ref="account_voucher.view_vendor_payment_form"/>
+      <field name="arch" type="xml">
+        <field name="amount" position="attributes">
+          <attribute name="context">{'line_cr_ids': line_cr_ids, 'line_dr_ids': line_dr_ids}</attribute>
+        </field>
+      </field>
+    </record>
+  </data>
+</openerp>

--- a/account_voucher_no_auto_lines/account_voucher_view.xml
+++ b/account_voucher_no_auto_lines/account_voucher_view.xml
@@ -37,6 +37,9 @@
         <field name="journal_id" position="attributes">
           <attribute name="context">{'allow_auto_lines': True}</attribute>
         </field>
+        <field name="amount" position="attributes">
+          <attribute name="context">{'allow_auto_lines': True}</attribute>
+        </field>
       </field>
     </record>
 

--- a/account_voucher_no_auto_lines/tests/__init__.py
+++ b/account_voucher_no_auto_lines/tests/__init__.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+
+from . import (
+    test_voucher
+)
+
+checks = [
+    test_voucher,
+]

--- a/account_voucher_no_auto_lines/tests/test_voucher.py
+++ b/account_voucher_no_auto_lines/tests/test_voucher.py
@@ -87,8 +87,6 @@ class test_account_voucher(common.TransactionCase):
                 voucher.payment_rate_currency_id.id,
                 voucher.company_id.id,
                 context=self.context)
-
-
                         
         voucher = self.model.read(self.cr, self.uid, voucher_id)
 

--- a/account_voucher_no_auto_lines/tests/test_voucher.py
+++ b/account_voucher_no_auto_lines/tests/test_voucher.py
@@ -113,7 +113,6 @@ class test_account_voucher(common.TransactionCase):
             voucher.currency_id.id,
             voucher.type,
             voucher.date,
-            context=context
         )
 
         debit = val['value']['line_dr_ids']

--- a/account_voucher_no_auto_lines/tests/test_voucher.py
+++ b/account_voucher_no_auto_lines/tests/test_voucher.py
@@ -2,6 +2,7 @@
 
 from openerp.tests import common
 
+
 class test_account_voucher(common.TransactionCase):
 
     def setUp(self):
@@ -77,17 +78,18 @@ class test_account_voucher(common.TransactionCase):
         voucher = self.model.browse(self.cr, self.uid, voucher_id)
 
         val = voucher.onchange_amount(
-                voucher.amount,
-                voucher.payment_rate,
-                voucher.partner_id.id,
-                voucher.journal_id.id,
-                voucher.currency_id.id,
-                'payment',
-                voucher.date,
-                voucher.payment_rate_currency_id.id,
-                voucher.company_id.id,
-                context=self.context)
-                        
+            voucher.amount,
+            voucher.payment_rate,
+            voucher.partner_id.id,
+            voucher.journal_id.id,
+            voucher.currency_id.id,
+            'payment',
+            voucher.date,
+            voucher.payment_rate_currency_id.id,
+            voucher.company_id.id,
+            context=self.context
+        )
+
         voucher = self.model.read(self.cr, self.uid, voucher_id)
 
         self.assertEqual(voucher['line_cr_ids'], [])

--- a/account_voucher_no_auto_lines/tests/test_voucher.py
+++ b/account_voucher_no_auto_lines/tests/test_voucher.py
@@ -1,0 +1,105 @@
+# -*- coding: utf-8 -*-
+
+from openerp.tests import common
+
+class test_account_voucher(common.TransactionCase):
+
+    def setUp(self):
+        super(test_account_voucher, self).setUp()
+
+        self.user_model = self.registry("res.users")
+
+        self.context = self.user_model.context_get(self.cr, self.uid)
+
+        self.model = self.registry('account.voucher')
+        self.line = self.registry('account.voucher.line')
+
+    def createVoucher(self, **kwargs):
+        """
+        name required
+        account_id required
+        """
+        return self.model.create(self.cr, self.uid, kwargs)
+
+    def createLine(self, **kwargs):
+        """
+        voucher_id required
+        account_id required
+        """
+        return self.line.create(self.cr, self.uid, kwargs)
+
+    def test_onchange_amount(self):
+        """
+        Test if we can create an account
+        and call the onchange_amount function and
+        expect the returned value to have the same lines as
+        before the call
+        """
+
+        voucher_id = self.createVoucher(name="test",
+                                        amount=0,
+                                        account_id=self.uid)
+
+        voucher = self.model.read(self.cr, self.uid, voucher_id)
+
+        self.assertEqual(voucher['line_cr_ids'], [])
+        self.assertEqual(voucher['line_dr_ids'], [])
+
+        self.model.write(self.cr, self.uid, voucher_id, {
+            "amount": 100,
+        })
+
+        voucher = self.model.read(self.cr, self.uid, voucher_id)
+
+        self.assertEqual(voucher['amount'], 100)
+        self.assertEqual(voucher['line_cr_ids'], [])
+        self.assertEqual(voucher['line_dr_ids'], [])
+
+        line1 = self.createLine(voucher_id=voucher_id,
+                                type="cr",
+                                amount=123.45,
+                                account_id=self.uid)
+
+        line_record = self.line.read(self.cr, self.uid, line1)
+        voucher = self.model.read(self.cr, self.uid, voucher_id)
+
+        self.assertNotEqual(line1, 0)
+        self.assertEqual(line_record['type'], 'cr')
+
+        self.assertEqual(len(voucher['line_cr_ids']), 1)
+        self.assertEqual(voucher['line_cr_ids'][0], line1)
+        self.assertEqual(voucher['line_dr_ids'], [])
+
+        self.model.write(self.cr, self.uid, voucher_id, {
+            "amount": 123.46
+        })
+
+        voucher = self.model.browse(self.cr, self.uid, voucher_id)
+
+        val = voucher.onchange_amount(
+                voucher.amount,
+                voucher.payment_rate,
+                voucher.partner_id.id,
+                voucher.journal_id.id,
+                voucher.currency_id.id,
+                'payment',
+                voucher.date,
+                voucher.payment_rate_currency_id.id,
+                voucher.company_id.id,
+                context=self.context)
+
+
+                        
+        voucher = self.model.read(self.cr, self.uid, voucher_id)
+
+        self.assertEqual(voucher['line_cr_ids'], [])
+        self.assertEqual(voucher['line_dr_ids'], [])
+
+        credit = val['value']['line_cr_ids']
+        debit = val['value']['line_dr_ids']
+
+        self.assertEqual(len(credit), 1)
+        self.assertEqual(len(debit), 0)
+
+        self.assertEqual(voucher['amount'], 123.46)
+        self.assertEqual(credit[0]['amount'], 123.45)

--- a/account_voucher_no_auto_lines/tests/test_voucher.py
+++ b/account_voucher_no_auto_lines/tests/test_voucher.py
@@ -21,6 +21,7 @@
 ###############################################################################
 
 from openerp.tests import common
+from openerp import netsvc
 
 
 class test_account_voucher(common.TransactionCase):
@@ -65,9 +66,10 @@ class test_account_voucher(common.TransactionCase):
                 })],
             }, context=context)
 
-        self.invoice_model.invoice_open(
-            cr, uid, [self.invoice_id],
-            context=context)
+        # Create accounting moves for the invoice
+        wf_service = netsvc.LocalService('workflow')
+        wf_service.trg_validate(
+            uid, 'account.invoice', self.invoice_id, 'invoice_open', cr)
 
         self.voucher_id = self.voucher_model.create(
             cr, uid, {

--- a/account_voucher_supplier_invoice_number/voucher.py
+++ b/account_voucher_supplier_invoice_number/voucher.py
@@ -29,8 +29,8 @@ class voucher_line(orm.Model):
         move_line = self.pool.get('account.move.line').browse(
             cr, uid, move_line_id, context)
         return (
-            move_line.invoice and move_line.invoice.supplier_invoice_number
-            or '')
+            move_line.invoice and
+            move_line.invoice.supplier_invoice_number or '')
 
     def _get_supplier_invoice_number(
         self, cr, uid, ids, name, args, context=None

--- a/nan_account_bank_statement/account_statement.py
+++ b/nan_account_bank_statement/account_statement.py
@@ -207,8 +207,9 @@ class account_bank_statement_line(osv.osv):
                 account_type = 'general'
                 if reconcile_line.partner_id:
                     if (
-                        reconcile_line.partner_id.property_account_receivable
-                        == reconcile_line.account_id
+                        reconcile_line.partner_id.
+                        property_account_receivable ==
+                        reconcile_line.account_id
                     ):
                         account_type = 'customer'
                     else:

--- a/purchase_payment/__init__.py
+++ b/purchase_payment/__init__.py
@@ -19,9 +19,9 @@
 #
 #
 
+from . import purchase_payment
+
 """
 Extension of the purchase orders to add payment info.
 """
 __author__ = "Borja López Soilán (Pexego) <borjals@pexego.es>"
-
-from . import purchase_payment

--- a/purchase_payment/__init__.py
+++ b/purchase_payment/__init__.py
@@ -21,7 +21,4 @@
 
 from . import purchase_payment
 
-"""
-Extension of the purchase orders to add payment info.
-"""
 __author__ = "Borja López Soilán (Pexego) <borjals@pexego.es>"

--- a/purchase_payment/purchase_payment.py
+++ b/purchase_payment/purchase_payment.py
@@ -19,14 +19,14 @@
 #
 #
 
+from osv import fields, osv
+
 """
 Extension of the purchase orders to add payment info.
 
 Based on the sale_payment module.
 """
 __author__ = "Borja López Soilán (Pexego) <borjals@pexego.es>"
-
-from osv import fields, osv
 
 
 class purchase_order(osv.osv):

--- a/purchase_payment/purchase_payment.py
+++ b/purchase_payment/purchase_payment.py
@@ -21,15 +21,15 @@
 
 from osv import fields, osv
 
-"""
-Extension of the purchase orders to add payment info.
-
-Based on the sale_payment module.
-"""
 __author__ = "Borja López Soilán (Pexego) <borjals@pexego.es>"
 
 
 class purchase_order(osv.osv):
+    """
+    Extension of the purchase orders to add payment info.
+
+    Based on the sale_payment module.
+    """
     _inherit = 'purchase.order'
     _columns = {
         'payment_term': fields.many2one(


### PR DESCRIPTION
Added tests and refactored some parts of the code. It's not possible to keep old lines as they are unlinked later by the base class. When the model is reloaded, it will try to load some line ids that are deleted.

Returning new lines as fresh id is a way to make it work correctly. The downside of this module is that when clicking on discard, it won't be able to refresh the model as the old lines were deleted. This problem is by design as lines should be added automatically and recreated automatically which means that they never wondered to save the state of the lines in case you want to discard changes. 
