### PR TITLE
Avoid trying to remove same move more than once

### DIFF
--- a/account_payment_extension/payment.py
+++ b/account_payment_extension/payment.py
@@ -208,7 +208,7 @@ class PaymentOrder(orm.Model):
         for move in self.browse(cr, uid, ids, context=context):
             # Search for any line
             for line in move.line_ids:
-                if line.payment_move_id:
+                if line.payment_move_id and not line.payment_move_id.id in remove:
                     remove += [line.payment_move_id.id]
         self.pool['account.move'].button_cancel(cr, uid, remove,
                                                 context=context)


### PR DESCRIPTION
When you try to cancel a "Rec. payment order" that has more than one payment line, you get the following, because the "remove" list has duplicate items

Server Traceback (most recent call last):
  File "/opt/openerp/modules/web/common/http.py", line 593, in send
    return openerp.netsvc.dispatch_rpc(service_name, method, args)
  File "/opt/openerp/parts/openobject-server/openerp/netsvc.py", line 360, in dispatch_rpc
    result = ExportService.getService(service_name).dispatch(method, params)
  File "/opt/openerp/parts/openobject-server/openerp/service/web_services.py", line 586, in dispatch
    res = fn(db, uid, _params)
  File "/opt/openerp/parts/openobject-server/openerp/osv/osv.py", line 186, in execute_kw
    return self.execute(db, uid, obj, method, *args, *_kw or {})
  File "/opt/openerp/parts/openobject-server/openerp/osv/osv.py", line 129, in wrapper
    return f(self, dbname, _args, *_kwargs)
  File "/opt/openerp/parts/openobject-server/openerp/osv/osv.py", line 195, in execute
    res = self.execute_cr(cr, uid, obj, method, _args, *_kw)
  File "/opt/openerp/parts/openobject-server/openerp/osv/osv.py", line 183, in execute_cr
    return getattr(object, method)(cr, uid, _args, *_kw)
  File "/opt/openerp/modules/account_voucher/account_voucher.py", line 1419, in button_cancel
    return super(account_bank_statement, self).button_cancel(cr, uid, ids, context=context)
  File "/opt/openerp/modules/account/account_cash_statement.py", line 338, in button_cancel
    super(account_cash_statement, self).button_cancel(cr, uid, ids, context=context)
  File "/opt/openerp/modules/account/account_bank_statement.py", line 380, in button_cancel
    account_move_obj.unlink(cr, uid, move_ids, context)
  File "/opt/openerp/modules/account/account.py", line 1454, in unlink
    obj_move_line._update_check(cr, uid, line_ids, context)
  File "/opt/openerp/modules/account/account_move_line.py", line 1229, in _update_check
    err_msg = _('Move name (id): %s (%s)') % (line.move_id.name, str(line.move_id.id))
  File "/opt/openerp/parts/openobject-server/openerp/osv/orm.py", line 478, in __getattr__
    raise AttributeError(e)
AttributeError: 'Field move_id not found in browse_record(account.move.line, 24143)' 

Reported in https://groups.google.com/forum/#!topic/openerp-spain/4-7oN7iQajY
