### PR TITLE
ADD account_payment_order_to_voucher module

### DIFF
--- a/account_payment_order_to_voucher/README.rst
+++ b/account_payment_order_to_voucher/README.rst
@@ -1,0 +1,51 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+========================
+Payment order to voucher
+========================
+
+This module allows to generate supplier vouchers from payment order,
+based on payment order data
+
+Usage
+=====
+
+For 'done' payment orders, click on 'Create vouchers' button
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/96/8.0
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues <https://github.com/OCA/account-payment/issues>`_.
+In case of trouble, please check there if your issue has already been reported.
+If you spotted it first, help us smashing it by providing a detailed and welcomed feedback
+`here <https://github.com/OCA/account-payment/issues/new?body=module:%20account_payment_order_to_voucher%0Aversion:%208.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+
+
+Credits
+=======
+
+Contributors
+------------
+
+* Lorenzo Battistini <lorenzo.battistini@agilebg.com>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit http://odoo-community.org.

--- a/account_payment_order_to_voucher/__init__.py
+++ b/account_payment_order_to_voucher/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+#
+#   See __openerp__.py about license
+#
+
+from . import models

--- a/account_payment_order_to_voucher/__openerp__.py
+++ b/account_payment_order_to_voucher/__openerp__.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2015 Lorenzo Battistini - Agile Business Group
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published
+#    by the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+{
+    'name': "Payment order to voucher",
+    'version': '8.0.1.0.0',
+    'category': 'Accounting & Finance',
+    'author': 'Agile Business Group, Odoo Community Association (OCA)',
+    'website': 'http://www.agilebg.com',
+    'license': 'AGPL-3',
+    "depends": [
+        'account_payment',
+        'account_voucher',
+    ],
+    "data": [
+        'views/payment_order_view.xml',
+    ],
+    "installable": True,
+}

--- a/account_payment_order_to_voucher/models/__init__.py
+++ b/account_payment_order_to_voucher/models/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+#
+#   See __openerp__.py about license
+#
+
+from . import payment_order

--- a/account_payment_order_to_voucher/models/payment_order.py
+++ b/account_payment_order_to_voucher/models/payment_order.py
@@ -1,0 +1,98 @@
+# -*- coding: utf-8 -*-
+#
+#   See __openerp__.py about license
+#
+
+from openerp import models, fields, api, _
+from openerp.exceptions import Warning
+
+
+class PaymentOrder(models.Model):
+    _inherit = 'payment.order'
+    voucher_ids = fields.Many2many(
+        'account.voucher', string='Vouchers', readonly=True)
+
+    def get_lines_by_partner(self, order):
+        lines_by_partner = {}
+        if order.voucher_ids:
+            raise Warning(
+                _("Payment order %s already has vouchers")
+                % order.reference)
+        if order.state != 'done':
+            raise Warning(
+                _("Payment order %s is not in 'done' state")
+                % order.reference)
+        for line in order.line_ids:
+            if line.partner_id.id not in lines_by_partner:
+                lines_by_partner[line.partner_id.id] = self.env['payment.line']
+            lines_by_partner[line.partner_id.id] |= line
+        return lines_by_partner
+
+    def _compute_lines_total(self, payment_lines):
+        return sum(payment_lines.mapped('amount_currency'))
+
+    def _get_currency_id(self, payment_lines):
+        currency_ids = payment_lines.mapped('currency').ids
+        if len(currency_ids) > 1:
+            raise Warning(
+                _("Every order lines must have the same currency"))
+        return currency_ids[0]
+
+    def _build_voucher_header(self, payment_lines):
+        total = self._compute_lines_total(payment_lines)
+
+        # every line has the same order and partner
+        order = payment_lines[0].order_id
+        partner = payment_lines[0].partner_id
+
+        currency_id = self._get_currency_id(payment_lines)
+        voucher_vals = {
+            'type': 'payment',
+            'name': order.reference,
+            'partner_id': partner.id,
+            'journal_id': order.mode.journal.id,
+            'account_id': order.mode.journal.default_debit_account_id.id,
+            'company_id': order.company_id.id,
+            'currency_id': currency_id,
+            'date': order.date_done,
+            'amount': total,
+            }
+        return voucher_vals
+
+    def _build_voucher_lines(self, payment_lines, voucher):
+        vals_list = []
+        for line in payment_lines:
+            vals = {
+                'voucher_id': voucher.id,
+                'type': 'dr',
+                'account_id': line.move_line_id.account_id.id,
+                'amount': line.amount_currency,
+                'move_line_id': line.move_line_id.id,
+                }
+            vals_list.append(vals)
+        return vals_list
+
+    @api.multi
+    def generate_vouchers(self):
+        voucher_model = self.env['account.voucher']
+        voucher_line_model = self.env['account.voucher.line']
+        vouchers = []
+        for order in self:
+            order_vouchers = []
+            lines_by_partner = self.get_lines_by_partner(order)
+            for partner_id in lines_by_partner:
+                payment_lines = lines_by_partner[partner_id]
+                voucher_vals = self._build_voucher_header(payment_lines)
+                voucher = voucher_model.create(voucher_vals)
+                line_vals_list = self._build_voucher_lines(
+                    payment_lines, voucher)
+                for line_vals in line_vals_list:
+                    voucher_line_model.create(line_vals)
+                order_vouchers.append(voucher)
+            order.voucher_ids = [v.id for v in order_vouchers]
+            vouchers.extend(order_vouchers)
+
+        action_res = self.env['ir.actions.act_window'].for_xml_id(
+            'account_voucher', 'action_vendor_payment')
+        action_res['domain'] = [('id', 'in', [v.id for v in vouchers])]
+        return action_res

--- a/account_payment_order_to_voucher/tests/__init__.py
+++ b/account_payment_order_to_voucher/tests/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+#
+#   See __openerp__.py about license
+#
+
+from . import test_payment_order

--- a/account_payment_order_to_voucher/tests/test_payment_order.py
+++ b/account_payment_order_to_voucher/tests/test_payment_order.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+#
+#   See __openerp__.py about license
+#
+
+from openerp.tests.common import TransactionCase
+from openerp import fields
+
+
+class TestOrder(TransactionCase):
+
+    def test_payment_order(self):
+        payment_wizard = self.env['payment.order.create']
+        demo_invoice_0 = self.env.ref('account.demo_invoice_0')
+        payment_order_1 = self.env.ref('account_payment.payment_order_1')
+        cr, uid = self.cr, self.uid
+        demo_invoice_0.check_total = 14
+        self.registry('account.invoice').signal_workflow(
+            cr, uid, [demo_invoice_0.id], 'invoice_open')
+        self.registry('payment.order').signal_workflow(
+            cr, uid, [payment_order_1.id], 'open')
+        wizard = payment_wizard.create({
+            'duedate': fields.Date.today(),
+            'entries': [(6, 0, [demo_invoice_0.move_id.line_id[0].id])]
+            })
+        wizard.with_context({
+            'active_model': 'payment.order',
+            'active_ids': [payment_order_1.id],
+            'active_id': payment_order_1.id,
+            }).create_payment()
+        payment_order_1.set_done()
+        payment_order_1.generate_vouchers()
+        self.assertEqual(len(payment_order_1.voucher_ids), 1)
+        payment_order_1.voucher_ids[0].proforma_voucher()
+        self.assertEqual(demo_invoice_0.state, 'paid')

--- a/account_payment_order_to_voucher/views/payment_order_view.xml
+++ b/account_payment_order_to_voucher/views/payment_order_view.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <record id="view_payment_order_form" model="ir.ui.view">
+            <field name="name">payment.order.form</field>
+            <field name="model">payment.order</field>
+            <field name="inherit_id" ref="account_payment.view_payment_order_form"></field>
+            <field name="arch" type="xml">
+                <div class=" oe_right oe_button_box" position="after">
+                    <div class=" oe_right oe_button_box">
+                        <button class="oe_inline oe_stat_button oe_right" name="generate_vouchers" string="Create vouchers"
+                        type="object" attrs="{'invisible':['|',('state','!=','done'),('vouchers_ids','!=',False)]}"
+                        icon="fa-pencil-square-o" widget="statinfo"/>
+                    </div>
+                </div>
+                <field name="line_ids" position="after">
+                    <separator string="Vouchers"></separator>
+                    <field name="voucher_ids"></field>
+                </field>
+            </field>
+        </record>
+
+    </data>
+</openerp>


### PR DESCRIPTION
# 
# Payment order to voucher

This module allows to generate supplier vouchers from payment order,
based on payment order data
# Usage

For 'done' payment orders, click on 'Create vouchers' button
