### PR TITLE
check if currency id not changed per company, remove it from create v…

### DIFF
--- a/account_due_list/models/account_move_line.py
+++ b/account_due_list/models/account_move_line.py
@@ -51,7 +51,7 @@ class AccountMoveLine(models.Model):
     @api.depends('date_maturity', 'debit', 'credit', 'reconcile_id',
                  'reconcile_partial_id', 'account_id.reconcile',
                  'amount_currency', 'reconcile_partial_id.line_partial_ids',
-                 'currency_id', 'company_id.currency_id')
+                 'currency_id')
     def _maturity_residual(self):
         """
             inspired by amount_residual


### PR DESCRIPTION
…alues

This PR solve an issue related by [this write method](https://github.com/odoo/odoo/commit/46721a88bff1aa0f582bb9cd635422a00c6542d3#diff-1a513ea93ae1aeca4005dcf8b810ed5aR154)
This method, if is also installed a module like [this](https://github.com/archetipo/account-payment/blob/9.0/account_due_list/account_move_line.py#L54) , generate a recalculation of all move lines, because trigger onchanege of currency_id
