### PR TITLE
[FIX] account_payment_order_to_voucher: Fix Travis with account_banking_payment_export

### DIFF
--- a/account_payment_order_to_voucher/tests/test_payment_order.py
+++ b/account_payment_order_to_voucher/tests/test_payment_order.py
@@ -10,9 +10,13 @@ from openerp import fields
 class TestOrder(TransactionCase):
 
     def test_payment_order(self):
-        payment_wizard = self.env['payment.order.create']
         demo_invoice_0 = self.env.ref('account.demo_invoice_0')
         payment_order_1 = self.env.ref('account_payment.payment_order_1')
+        payment_wizard = self.env['payment.order.create'].with_context({
+            'active_model': 'payment.order',
+            'active_ids': [payment_order_1.id],
+            'active_id': payment_order_1.id,
+        })
         cr, uid = self.cr, self.uid
         demo_invoice_0.check_total = 14
         self.registry('account.invoice').signal_workflow(
@@ -23,11 +27,7 @@ class TestOrder(TransactionCase):
             'duedate': fields.Date.today(),
             'entries': [(6, 0, [demo_invoice_0.move_id.line_id[0].id])]
             })
-        wizard.with_context({
-            'active_model': 'payment.order',
-            'active_ids': [payment_order_1.id],
-            'active_id': payment_order_1.id,
-            }).create_payment()
+        wizard.create_payment()
         payment_order_1.set_done()
         payment_order_1.generate_vouchers()
         self.assertEqual(len(payment_order_1.voucher_ids), 1)


### PR DESCRIPTION
Both modules installed conflict because the tests of this module doesn't set correctly active_model context variable.
