### PR TITLE
[8.0][IMP][account_due_list] Add invoice salesperson to account.move.line for filtering and grouping

### DIFF
--- a/account_due_list/models/account_move_line.py
+++ b/account_due_list/models/account_move_line.py
@@ -41,6 +41,9 @@ class AccountMoveLine(models.Model):
     stored_invoice_id = fields.Many2one(
         comodel_name='account.invoice', compute='_compute_invoice',
         string='Invoice', store=True)
+    invoice_user_id = fields.Many2one(
+        comodel_name='res.users', related='stored_invoice_id.user_id',
+        string="Invoice salesperson", store=True)
     maturity_residual = fields.Float(
         compute='_maturity_residual', string="Residual Amount", store=True,
         help="The residual amount on a receivable or payable of a journal "

--- a/account_due_list/views/payment_view.xml
+++ b/account_due_list/views/payment_view.xml
@@ -47,6 +47,7 @@
                 <field name="account_id"/>
                 <field name="partner_id"/>
                 <field name="invoice"/>
+                <field name="invoice_user_id"/>
                 <field name="invoice_origin"/>
                 <field name="date_maturity"/>
                 <group expand="0" string="Group By...">
@@ -54,6 +55,7 @@
                     <filter string="Invoice" icon="terp-folder-orange" domain="[]" context="{'group_by':'stored_invoice_id'}"/>
                     <filter string="Due date" icon="terp-go-today" domain="[]" context="{'group_by':'day'}"/>
                     <filter string="Month" icon="terp-go-month" domain="[]" context="{'group_by':'date_maturity'}"/>
+                    <filter string="Salesperson" icon="terp-sale" domain="[]" context="{'group_by':'invoice_user_id'}"/>
                </group>
            </search>
         </field>
@@ -70,7 +72,7 @@
         <field name="search_view_id" ref="view_payments_filter"/>
         <field name="domain">[('account_id.type', 'in', ['receivable', 'payable'])]</field>
     </record>
-    
+
     <menuitem name="Payments and due list"
               parent="account.menu_finance_entries"
               action="action_invoice_payments"


### PR DESCRIPTION
This PR adds a stored related field `invoice_user_id` for filtering and grouping `account.move.line` by salesperson
