### PR TITLE
[IMP] adds number of days overdue to the report. Allows to search by # days overdue.

### DIFF
--- a/account_due_list/models/account_move_line.py
+++ b/account_due_list/models/account_move_line.py
@@ -26,6 +26,7 @@
 ##############################################################################
 
 from openerp import models, fields, api
+import datetime
 
 
 class AccountMoveLine(models.Model):
@@ -45,7 +46,14 @@ class AccountMoveLine(models.Model):
         compute='_maturity_residual', string="Residual Amount", store=True,
         help="The residual amount on a receivable or payable of a journal "
              "entry expressed in the company currency.")
+    due_amount = fields.Float(
+        compute='_compute_due_amount', string="Due Amount",
+        help="The due amount on a receivable or payable of a journal "
+             "entry expressed in the company currency.")
     day = fields.Char(compute='_get_day', string='Day', size=16, store=True)
+    days_overdue = fields.Integer(compute='_compute_days_overdue',
+                                  search='_search_days_overdue',
+                                  string='Days overdue')
 
     @api.multi
     @api.depends('date_maturity', 'debit', 'credit', 'reconcile_id',
@@ -53,6 +61,19 @@ class AccountMoveLine(models.Model):
                  'amount_currency', 'reconcile_partial_id.line_partial_ids',
                  'currency_id', 'company_id.currency_id')
     def _maturity_residual(self):
+        """
+            inspired by amount_residual
+        """
+        for move_line in self:
+            sign = (move_line.debit - move_line.credit) < 0 and -1 or 1
+            move_line.maturity_residual = move_line.amount_residual * sign
+
+    @api.multi
+    @api.depends('date_maturity', 'debit', 'credit', 'reconcile_id',
+                 'reconcile_partial_id', 'account_id.reconcile',
+                 'amount_currency', 'reconcile_partial_id.line_partial_ids',
+                 'currency_id', 'company_id.currency_id')
+    def _compute_due_amount(self):
         """
             inspired by amount_residual
         """
@@ -75,6 +96,32 @@ class AccountMoveLine(models.Model):
                 line.day = line.date_maturity
             else:
                 line.day = False
+
+    @api.depends('date_maturity')
+    def _compute_days_overdue(self):
+        today_date = fields.Date.from_string(fields.Date.today())
+        for line in self:
+            if line.date_maturity:
+                date_maturity = fields.Date.from_string(
+                    line.date_maturity)
+                days_overdue = (today_date - date_maturity).days
+                if days_overdue > 0:
+                    line.days_overdue = days_overdue
+
+    def _search_days_overdue(self, operator, value):
+        due_date = fields.Date.from_string(fields.Date.today()) - \
+                   datetime.timedelta(days=value)
+        if operator in ('!=', '<>', 'in', 'not in'):
+            raise ValueError('Invalid operator: %s' % (operator,))
+        if operator == '>':
+            operator = '<'
+        elif operator == '<':
+            operator = '>'
+        elif operator == '>=':
+            operator = '<='
+        elif operator == '<=':
+            operator = '>='
+        return [('date_maturity', operator, due_date)]
 
     @api.model
     def fields_view_get(self, view_id=None, view_type='form', toolbar=False,

--- a/account_due_list/views/payment_view.xml
+++ b/account_due_list/views/payment_view.xml
@@ -12,6 +12,7 @@
             <tree string="Payments" colors="grey:reconcile_id!=False;red:date_maturity&lt;current_date">
                 <field name="stored_invoice_id" readonly="1"/>
                 <field name="invoice_date" readonly="1"/>
+                <field name="date_maturity" readonly="1"/>
                 <field name="invoice_origin" readonly="1"/>
                 <field name="partner_id" readonly="1"/>
                 <field name="partner_ref" readonly="1"/>
@@ -20,7 +21,7 @@
                 <field name="debit" readonly="1" sum="Total Debit"/>
                 <field name="credit" readonly="1" sum="Total Credit"/>
                 <field name="maturity_residual" sum="Total Residual"/>
-                <field name="date_maturity"/>
+                <field name="days_overdue" readonly="1"/>
                 <field name="move_id" readonly="1"/>
                 <field name="reconcile_id" readonly="1"/>
                 <field name="reconcile_partial_id" readonly="1"/>
@@ -43,12 +44,21 @@
                 <filter icon="terp-dolar_ok!" string="Unreconciled" domain="[('reconcile_id','=',False)]" help="Unreconciled payments"/>
                 <separator orientation="vertical"/>
                 <filter icon="terp-go-today" string="Overdue" domain="[('date_maturity','&lt;',time.strftime('%%Y-%%m-%%d'))]" help="Overdue payments" name="overdue"/>
+                <filter string="Overdue 0-29 days"
+                        domain="[('days_overdue','>',0), ('days_overdue','&lt;',30)]"/>
+                <filter string="Overdue 30-59 days"
+                        domain="[('days_overdue','>',30), ('days_overdue','&lt;',60)]"/>
+                <filter string="Overdue 60-89 days"
+                        domain="[('days_overdue','>',60), ('days_overdue','&lt;',90)]"/>
+                <filter string="Overdue > 90 days"
+                        domain="[('days_overdue','>',90)]"/>
                 <separator orientation="vertical"/>
                 <field name="account_id"/>
                 <field name="partner_id"/>
                 <field name="invoice"/>
                 <field name="invoice_origin"/>
                 <field name="date_maturity"/>
+                <field name="days_overdue"/>
                 <group expand="0" string="Group By...">
                     <filter string="Partner" icon="terp-partner" domain="[]" context="{'group_by':'partner_id'}"/>
                     <filter string="Invoice" icon="terp-folder-orange" domain="[]" context="{'group_by':'stored_invoice_id'}"/>


### PR DESCRIPTION
This PR adds a new column to the "Payments and due list" called 'Days overdue'.

It allows to search on the number of days overdue of move lines. Predefined filters are provided to search for AR or AP overdue by 0-29, 30-59, 60-89 and >= 90.

![image](https://cloud.githubusercontent.com/assets/7683926/16751153/8241897e-47d7-11e6-90be-0314db696499.png)
