### PR TITLE
Fix typo in view of account_payment_order_to_voucher

### DIFF
--- a/account_payment_order_to_voucher/views/payment_order_view.xml
+++ b/account_payment_order_to_voucher/views/payment_order_view.xml
@@ -9,7 +9,7 @@
                 <div class=" oe_right oe_button_box" position="after">
                     <div class=" oe_right oe_button_box">
                         <button class="oe_inline oe_stat_button oe_right" name="generate_vouchers" string="Create vouchers"
-                        type="object" attrs="{'invisible':['|',('state','!=','done'),('vouchers_ids','!=',False)]}"
+                        type="object" attrs="{'invisible':['|',('state','!=','done'),('voucher_ids','!=',False)]}"
                         icon="fa-pencil-square-o" widget="statinfo"/>
                     </div>
                 </div>


### PR DESCRIPTION
account_payment_order_to_voucher adds a button to the payment.order form view, but it misspells a field name in the button' s 'attr' attribute. It looks for vouchers_ids instead of voucher_ids.
