### PR TITLE
[8.0] [IMP] [account_due_list] add the name of the move to the list view

### DIFF
--- a/account_due_list/views/payment_view.xml
+++ b/account_due_list/views/payment_view.xml
@@ -13,6 +13,7 @@
                 <field name="stored_invoice_id" readonly="1"/>
                 <field name="invoice_date" readonly="1"/>
                 <field name="invoice_origin" readonly="1"/>
+                <field name="name" readonly="1" attrs=""/>
                 <field name="partner_id" readonly="1"/>
                 <field name="partner_ref" readonly="1"/>
                 <field name="payment_term_id" readonly="1"/>
@@ -44,6 +45,7 @@
                 <filter icon="terp-go-today" string="Overdue" domain="[('date_maturity','&lt;',time.strftime('%%Y-%%m-%%d'))]" help="Overdue payments" name="overdue"/>
                 <separator orientation="vertical"/>
                 <field name="account_id"/>
+                <field name="name"/>
                 <field name="partner_id"/>
                 <field name="invoice"/>
                 <field name="invoice_user_id"/>

--- a/account_due_list/views/payment_view.xml
+++ b/account_due_list/views/payment_view.xml
@@ -13,7 +13,7 @@
                 <field name="stored_invoice_id" readonly="1"/>
                 <field name="invoice_date" readonly="1"/>
                 <field name="invoice_origin" readonly="1"/>
-                <field name="name" readonly="1" attrs=""/>
+                <field name="name" readonly="1"/>
                 <field name="partner_id" readonly="1"/>
                 <field name="partner_ref" readonly="1"/>
                 <field name="payment_term_id" readonly="1"/>


### PR DESCRIPTION
 Problem: Key information, such as the supplier invoice number, does not appear in the due list. The information that appears in the list is inconsistent with the data shown in the list of move lines. The name of the move line is missing.
 Solution: Add the move line name to this list, as it provides valuable info.

Modules such as https://github.com/OCA/bank-statement-reconcile/tree/8.0/account_invoice_reference even make it more evident the need to show the move line name.
