### PR TITLE
[10.0][IMP] account_payment_return: Add return expenses functionality

### DIFF
--- a/account_payment_return/README.rst
+++ b/account_payment_return/README.rst
@@ -24,19 +24,18 @@ Another option to fill info is setting references and click match button to
 find matches with invoices, move lines or moves. This functionality is extended
 by other modules as *account_payment_return_import_sepa_pain*
 
+It's possible to add a commission amount on each line.
+
 Next, press button "Confirm" to create a new move line that removes the
 balance from the bank journal and reconcile items together to show payment
 history through it.
 
+After confirmation you can access from the payment form view to the move
+created.
+
 .. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
    :alt: Try me on Runbot
    :target: https://runbot.odoo-community.org/runbot/96/10.0
-
-Known issues / Roadmap
-======================
-
-* Add a button to see the created move.
-* Allow to add a commission amount on each line.
 
 Bug Tracker
 ===========
@@ -58,6 +57,7 @@ Contributors
 * Sergio Teruel <sergio.teruel@tecnativa.com>
 * Carlos Dauden <carlos.dauden@tecnativa.com>
 * David Vidal <david.vidal@tecnativa.com>
+* Luis M. Ontalba <luis.martinez@tecnativa.com>
 
 Maintainer
 ----------

--- a/account_payment_return/__manifest__.py
+++ b/account_payment_return/__manifest__.py
@@ -11,7 +11,7 @@
 
 {
     "name": "Account Payment Returns",
-    "version": "10.0.1.0.0",
+    "version": "10.0.1.1.0",
     "summary": "Manage the return of your payments",
     'license': 'AGPL-3',
     "depends": [

--- a/account_payment_return/__manifest__.py
+++ b/account_payment_return/__manifest__.py
@@ -27,6 +27,7 @@
         'security/ir.model.access.csv',
         'security/account_payment_return_security.xml',
         'views/payment_return_view.xml',
+        'views/account_journal_view.xml',
         'data/ir_sequence_data.xml',
         'views/account_invoice_view.xml',
     ],

--- a/account_payment_return/models/__init__.py
+++ b/account_payment_return/models/__init__.py
@@ -5,3 +5,4 @@ from . import payment_return
 from . import account_invoice
 from . import payment_return_reason
 from . import account_move
+from . import account_journal

--- a/account_payment_return/models/account_journal.py
+++ b/account_payment_return/models/account_journal.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 luis M. Ontalba <luis.martinez@tecnativa.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class AccountJournal(models.Model):
+    _inherit = "account.journal"
+
+    default_expense_account_id = fields.Many2one(
+        comodel_name='account.account', string='Default Expense Account',
+        help='Default account for commission expenses')
+    default_expense_partner_id = fields.Many2one(
+        comodel_name="res.partner", string="Default Expense Partner",
+        domain=[('supplier', '=', True)], help='Default partner for '
+                                               'commission expenses')

--- a/account_payment_return/models/payment_return.py
+++ b/account_payment_return/models/payment_return.py
@@ -158,7 +158,7 @@ class PaymentReturn(models.Model):
                 (move_line | move_line2).reconcile()
                 return_line.move_line_ids.mapped('matched_debit_ids').write(
                     {'origin_returned_move_ids': [(6, 0, returned_moves.ids)]})
-            if return_line.expense_amount and return_line.expense_account:
+            if return_line.expense_amount:
                 expense_lines_vals = []
                 expense_lines_vals.append({
                     'name': move.ref,
@@ -280,6 +280,13 @@ class PaymentReturnLine(models.Model):
     @api.onchange('move_line_ids')
     def _onchange_move_line(self):
         self._compute_amount()
+
+    @api.onchange('expense_amount')
+    def _onchange_expense_amount(self):
+        if self.expense_amount:
+            journal = self.return_id.journal_id
+            self.expense_account = journal.default_expense_account_id
+            self.expense_partner_id = journal.default_expense_partner_id
 
     @api.multi
     def match_invoice(self):

--- a/account_payment_return/models/payment_return.py
+++ b/account_payment_return/models/payment_return.py
@@ -4,6 +4,7 @@
 # Copyright 2013 Pedro M. Baeza <pedro.baeza@tecnativa.com>
 # Copyright 2014 Markus Schneider <markus.schneider@initos.com>
 # Copyright 2016 Carlos Dauden <carlos.dauden@tecnativa.com>
+# Copyright 2017 Luis M. Ontalba <luis.martinez@tecnativa.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import _, api, fields, models
@@ -157,6 +158,28 @@ class PaymentReturn(models.Model):
                 (move_line | move_line2).reconcile()
                 return_line.move_line_ids.mapped('matched_debit_ids').write(
                     {'origin_returned_move_ids': [(6, 0, returned_moves.ids)]})
+            if return_line.expense_amount and return_line.expense_account:
+                expense_lines_vals = []
+                expense_lines_vals.append({
+                    'name': move.ref,
+                    'move_id': move.id,
+                    'debit': 0.0,
+                    'credit': return_line.expense_amount,
+                    'partner_id': return_line.expense_partner_id.id,
+                    'account_id': (return_line.return_id.journal_id.
+                                   default_credit_account_id.id),
+                })
+                expense_lines_vals.append({
+                    'move_id': move.id,
+                    'debit': return_line.expense_amount,
+                    'name': move.ref,
+                    'credit': 0.0,
+                    'partner_id': return_line.expense_partner_id.id,
+                    'account_id': return_line.expense_account.id,
+                })
+                for expense_line_vals in expense_lines_vals:
+                    move_line_obj.with_context(
+                        check_move_validity=False).create(expense_line_vals)
             extra_lines_vals = return_line._prepare_extra_move_lines(move)
             for extra_line_vals in extra_lines_vals:
                 move_line_obj.create(extra_line_vals)
@@ -231,6 +254,13 @@ class PaymentReturnLine(models.Model):
         string='Amount',
         help="Returned amount. Can be different from the move amount",
         digits=dp.get_precision('Account'))
+    expense_account = fields.Many2one(
+        comodel_name='account.account', string='Expense Account')
+    expense_amount = fields.Float(string='Expense amount')
+    expense_partner_id = fields.Many2one(
+        comodel_name="res.partner", string="Expense partner",
+        domain=[('supplier', '=', True)],
+    )
 
     @api.multi
     def _compute_amount(self):

--- a/account_payment_return/tests/test_payment_return.py
+++ b/account_payment_return/tests/test_payment_return.py
@@ -2,6 +2,7 @@
 # Copyright 2015 Pedro M. Baeza <pedro.baeza@tecnativa.com>
 # Copyright 2016 Carlos Dauden <carlos.dauden@tecnativa.com>
 # Copyright 2017 David Vidal <david.vidal@tecnativa.com>
+# Copyright 2017 Luis M. Ontalba <luis.martinez@tecnativa.com>
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
 import json
@@ -80,7 +81,10 @@ class TestPaymentReturn(SavepointCase):
              'line_ids': [
                  (0, 0, {'partner_id': cls.partner.id,
                          'move_line_ids': [(6, 0, cls.payment_line.ids)],
-                         'amount': cls.payment_line.credit})]})
+                         'amount': cls.payment_line.credit,
+                         'expense_account': cls.account.id,
+                         'expense_amount': 10.0,
+                         'expense_partner_id': cls.partner.id})]})
 
     def test_confirm_error(self):
         self.payment_return.line_ids[0].move_line_ids = False
@@ -105,6 +109,7 @@ class TestPaymentReturn(SavepointCase):
         self.assertEqual(self.invoice.state, 'open')
         self.assertEqual(self.invoice.residual, self.receivable_line.debit)
         self.assertFalse(self.receivable_line.reconciled)
+        self.assertEqual(len(self.payment_return.move_id.line_ids), 4)
         with self.assertRaises(UserError):
             self.payment_return.unlink()
         self.payment_return.action_cancel()

--- a/account_payment_return/views/account_journal_view.xml
+++ b/account_payment_return/views/account_journal_view.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2017 Luis M. Ontalba <luis.martínez@tecnativa.com>
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl-3). -->
+
+<odoo>
+
+    <record id="view_account_journal_form" model="ir.ui.view">
+        <field name="name">account.journal.form</field>
+        <field name="model">account.journal</field>
+        <field name="inherit_id" ref="account.view_account_journal_form"/>
+        <field name="arch" type="xml">
+            <field name="default_debit_account_id" position="after">
+                <field name="default_expense_account_id"/>
+                <field name="default_expense_partner_id"/>
+            </field>
+        </field>
+    </record>
+
+</odoo>

--- a/account_payment_return/views/payment_return_view.xml
+++ b/account_payment_return/views/payment_return_view.xml
@@ -23,6 +23,7 @@
                         <field name="journal_id" domain="[('type', 'in', ['bank', 'cash'])]"/>
                         <field name="date"/>
                         <field name="company_id" groups="base.group_multi_company"/>
+                        <field name="move_id" readonly="True"/>
                     </group>
                     <notebook colspan="4">
                         <page string="Lines">
@@ -42,6 +43,12 @@
                                                     ('reconciled', '=', True)]"
                                             />
                                     <field name="amount"/>
+                                    <field name="expense_account"
+                                           attrs="{'required':[('expense_amount','!=', 0)]}" />
+                                    <field name="expense_amount"
+                                           attrs="{'required':[('expense_account','!=', False)]}"/>
+                                    <field name="expense_partner_id"
+                                           attrs="{'required':[('expense_account','!=', False)]}"/>
                                 </tree>
                             </field>
                         </page>

--- a/account_payment_return/views/payment_return_view.xml
+++ b/account_payment_return/views/payment_return_view.xml
@@ -43,10 +43,9 @@
                                                     ('reconciled', '=', True)]"
                                             />
                                     <field name="amount"/>
+                                    <field name="expense_amount" />
                                     <field name="expense_account"
                                            attrs="{'required':[('expense_amount','!=', 0)]}" />
-                                    <field name="expense_amount"
-                                           attrs="{'required':[('expense_account','!=', False)]}"/>
                                     <field name="expense_partner_id"
                                            attrs="{'required':[('expense_account','!=', False)]}"/>
                                 </tree>


### PR DESCRIPTION
Improvements:
* Adds commissions expenses on each return line. When confirming return the expense is incorporated to the created move.
* A link to the move created from the return view form.

cc @Tecnativa
