### PR TITLE
[11.0] [FIX] Category in account_cash_invoice (#1)

### DIFF
--- a/account_cash_invoice/__init__.py
+++ b/account_cash_invoice/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 
 from . import models

--- a/account_cash_invoice/__manifest__.py
+++ b/account_cash_invoice/__manifest__.py
@@ -1,14 +1,13 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2017 Creu Blanca
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 
 {
     'name': 'Account cash invoice',
-    'version': '11.0.1.0.0',
-    'category': 'Account',
+    'version': '11.0.1.1.0',
+    'category': 'Accounting',
     'author': "Creu Blanca,"
               "Odoo Community Association (OCA)",
-    'website': 'https://github.com/OCA/pos',
+    'website': 'https://github.com/OCA/account-payment',
     'summary': 'Pay and receive invoices from bank statements',
     "license": "LGPL-3",
     'depends': [

--- a/account_cash_invoice/models/__init__.py
+++ b/account_cash_invoice/models/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 
 from . import account_bank_statement_line

--- a/account_cash_invoice/models/account_bank_statement_line.py
+++ b/account_cash_invoice/models/account_bank_statement_line.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2017 Creu Blanca
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 

--- a/account_cash_invoice/tests/__init__.py
+++ b/account_cash_invoice/tests/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 
 from . import test_pay_invoice

--- a/account_cash_invoice/tests/test_pay_invoice.py
+++ b/account_cash_invoice/tests/test_pay_invoice.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2017 Creu Blanca <https://creublanca.es/>
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 

--- a/account_cash_invoice/wizard/__init__.py
+++ b/account_cash_invoice/wizard/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 
 from . import cash_invoice_in

--- a/account_cash_invoice/wizard/cash_invoice_in.py
+++ b/account_cash_invoice/wizard/cash_invoice_in.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2017 Creu Blanca
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 

--- a/account_cash_invoice/wizard/cash_invoice_out.py
+++ b/account_cash_invoice/wizard/cash_invoice_out.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2017 Creu Blanca
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 


### PR DESCRIPTION
This is a minor fix in the manifest.py file of account_cash_invoice:

Change category from "Account" to "Accounting" in order to follow the categories set in Odoo 11
Change the website to the repository web https://github.com/OCA/account-payment
Remove the lines # -- coding: utf-8 --