### PR TITLE
[IMP] account_check_printing_report_base: Compute due date through move lines

### DIFF
--- a/account_check_printing_report_base/__manifest__.py
+++ b/account_check_printing_report_base/__manifest__.py
@@ -7,7 +7,7 @@
 
 {
     "name": "Account Check Printing Report Base",
-    "version": "10.0.1.1.0",
+    "version": "10.0.1.1.1",
     "license": "AGPL-3",
     "author": "Eficent,"
               "Serpent Consulting Services Pvt. Ltd.,"

--- a/account_check_printing_report_base/report/check_print.py
+++ b/account_check_printing_report_base/report/check_print.py
@@ -27,13 +27,22 @@ class ReportCheckPrint(models.AbstractModel):
             for invoice in payment.invoice_ids:
                 amount_currency = 0.0
                 amount = 0.0
+                date_due = invoice.date_due
+                due_lines = invoice.move_id.mapped('line_ids').filtered(
+                    lambda x: (
+                        x.account_id.internal_type in
+                        ('receivable', 'payable') and x.date_maturity
+                    )
+                )
+                if due_lines:
+                    date_due = min(due_lines.mapped('date_maturity'))
                 line = {
-                    'date_due': invoice.date_due,
+                    'date_due': date_due,
                     'reference': invoice.reference,
                     'number': invoice.number,
                     'amount_total': invoice.amount_total,
                     'residual': invoice.residual,
-                    'paid_amount': 0.0
+                    'paid_amount': 0.0,
                 }
                 if invoice.type == 'out_refund':
                     line['amount_total'] *= -1


### PR DESCRIPTION
When you have confirmed the invoice and change the due date in the move lines instead of the invoice, the due date that appear on the checks is still the invoice one.

With this commit, you get that one, but falling back to the invoice one if not present on move lines (which is rare).

cc @Tecnativa