### PR TITLE
[10.0] [IMP] Add store=True to payment_term_id

### DIFF
--- a/account_due_list/models/account_move_line.py
+++ b/account_due_list/models/account_move_line.py
@@ -23,7 +23,7 @@ class AccountMoveLine(models.Model):
     partner_ref = fields.Char(related='partner_id.ref', string='Partner Ref')
     payment_term_id = fields.Many2one('account.payment.term',
                                       related='invoice_id.payment_term_id',
-                                      string='Payment Terms')
+                                      string='Payment Terms', store=True)
     stored_invoice_id = fields.Many2one(
         comodel_name='account.invoice', compute='_compute_invoice',
         string='Invoice', store=True)


### PR DESCRIPTION
I added store = True to the payment_term_id field to be able to insert it in the filters and in the group_by.