### PR TITLE
[IMP] account_check_printing: Allow to use other models

### DIFF
--- a/account_check_printing_report_base/__manifest__.py
+++ b/account_check_printing_report_base/__manifest__.py
@@ -6,7 +6,7 @@
 
 {
     "name": "Account Check Printing Report Base",
-    "version": "11.0.1.1.0",
+    "version": "11.0.1.1.1",
     "license": "AGPL-3",
     "author": "Eficent,"
               "Serpent Consulting Services Pvt. Ltd.,"

--- a/account_check_printing_report_base/models/account_journal.py
+++ b/account_check_printing_report_base/models/account_journal.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2017 Tecnativa.
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 

--- a/account_check_printing_report_base/report/check_print.py
+++ b/account_check_printing_report_base/report/check_print.py
@@ -4,7 +4,7 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 import time
-from odoo import api, exceptions, models, _
+from odoo import api, models
 from odoo.tools import float_is_zero
 
 
@@ -20,6 +20,8 @@ class ReportCheckPrint(models.AbstractModel):
 
     @api.multi
     def get_paid_lines(self, payments):
+        if self.env.context.get('active_model') != 'account.payment':
+            return {}
         lines = {}
         for payment in payments:
             lines[payment.id] = []
@@ -92,16 +94,15 @@ class ReportCheckPrint(models.AbstractModel):
 
     @api.multi
     def get_report_values(self, docids, data=None):
-        payments = self.env['account.payment'].browse(docids)
-        paid_lines = self.get_paid_lines(payments)
+        model = self.env.context.get('active_model', 'account.payment')
+        objects = self.env[model].browse(docids)
+        paid_lines = self.get_paid_lines(objects)
         docargs = {
             'doc_ids': docids,
-            'doc_model': 'account.payment',
-            'docs': payments,
+            'doc_model': models,
+            'docs': objects,
             'time': time,
             'fill_stars': self.fill_stars,
             'paid_lines': paid_lines
         }
-        if self.env.user.company_id.check_layout_id:
-            return docargs
-        raise exceptions.Warning(_('You must define a check layout'))
+        return docargs


### PR DESCRIPTION
This way, we could use account_check_printing_report_base with other kinds of elements, like `account.payment.order` from bank-payment