### PR TITLE
[12.0] [ADD] Payment Return Import SEPA: reason additional info

### DIFF
--- a/account_payment_return/models/payment_return.py
+++ b/account_payment_return/models/payment_return.py
@@ -235,6 +235,10 @@ class PaymentReturnLine(models.Model):
         oldname="reason",
         string='Return reason',
     )
+    reason_additional_information = fields.Char(
+        string="Return reason (info)",
+        help="Additional information on return reason.",
+    )
     reference = fields.Char(
         string='Reference',
         help="Reference to match moves from related documents")

--- a/account_payment_return/views/payment_return_view.xml
+++ b/account_payment_return/views/payment_return_view.xml
@@ -32,6 +32,7 @@
                                     <field name="date" />
                                     <field name="concept" />
                                     <field name="reason_id" />
+                                    <field name="reason_additional_information"/>
                                     <field name="partner_name" invisible="1"/>
                                     <field name="partner_id" />
                                     <field name="reference" />

--- a/account_payment_return_import/tests/test_import_file.py
+++ b/account_payment_return_import/tests/test_import_file.py
@@ -21,7 +21,8 @@ class TestPaymentReturnFile(TransactionCase):
     """
 
     def _test_transaction(
-            self, return_obj, reference=False, returned_amount=False):
+            self, return_obj, reference=False, returned_amount=False,
+            reason_add_info=False):
         """Check whether transaction with attributes passed was created.
 
         Actually this method also tests whether automatic creation of
@@ -33,6 +34,9 @@ class TestPaymentReturnFile(TransactionCase):
             domain.append(('amount', '=', returned_amount))
         if reference:
             domain.append(('reference', '=', reference))
+        if reason_add_info:
+            domain.append(
+                ('reason_additional_information', '=', reason_add_info))
         ids = transaction_model.search(domain)
         if not ids:
             # We will get assertion error, but to solve we need to see

--- a/account_payment_return_import_sepa_pain/test_files/test-sepa-unpaid.xml
+++ b/account_payment_return_import_sepa_pain/test_files/test-sepa-unpaid.xml
@@ -62,6 +62,7 @@ Unique End to End identifier for the transaction as assigned by the originator i
 <Rsn>
  <Cd>AC01</Cd>
  </Rsn>
+<AddtlInf>ACC NUMBER INVALID</AddtlInf>
  </StsRsnInf>
  <OrgnlTxRef>
  <Amt><InstdAmt Ccy="EUR">100</InstdAmt></Amt>

--- a/account_payment_return_import_sepa_pain/tests/test_import_sepa_pain.py
+++ b/account_payment_return_import_sepa_pain/tests/test_import_sepa_pain.py
@@ -34,6 +34,7 @@ class TestImport(TestPaymentReturnFile):
             {
                 'returned_amount': 100.00,
                 'reference': 'E2EID1',
+                'reason_add_info': 'ACC NUMBER INVALID',
             },
         ]
         self._test_return_import(

--- a/account_payment_return_import_sepa_pain/wizard/pain_parser.py
+++ b/account_payment_return_import_sepa_pain/wizard/pain_parser.py
@@ -66,6 +66,10 @@ class PainParser(object):
             ns, node, './ns:StsRsnInf/ns:Rsn/ns:Cd', transaction,
             'reason_code'
         )
+        self.add_value_from_node(
+            ns, node, './ns:StsRsnInf/ns:AddtlInf', transaction,
+            'reason_additional_information'
+        )
         details_node = node.xpath(
             './ns:OrgnlTxRef', namespaces={'ns': ns})
         if details_node:


### PR DESCRIPTION
New free text field on return lines: additional information on return reason.
This field is populated in account_payment_return_import_sepa_pain with the content of the AddtlInf tag.
This is useful when the return reason code is NARR, meaning the reason description does not match any known code but is in this tag.

---------------------
From #227 