### PR TITLE
[10.0][IMP] account_cash_discount_base: Allows to enter manual discount

### DIFF
--- a/account_cash_discount_base/README.rst
+++ b/account_cash_discount_base/README.rst
@@ -21,6 +21,9 @@ is still computed at invoice's validation.
 You can decide to calculate the discount amount based on the total price taxes
 included or not.
 
+You can also define a manual amount on invoice level if your company configuration
+allows it.
+
 
 Configuration
 =============
@@ -29,6 +32,7 @@ To configure the base amount type, you need to:
 
 #. Go to your companies
 #. Set the cash discount base amount type (including taxes or not)
+#. Set if you authorize or not manual cash discount
 
 You can also configure default discount percent and delay on the payment term.
 

--- a/account_cash_discount_base/__manifest__.py
+++ b/account_cash_discount_base/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     'name': 'Account Cash Discount Base',
-    'version': '10.0.1.0.0',
+    'version': '10.0.1.1.0',
     'license': 'AGPL-3',
     'author': 'ACSONE SA/NV,'
               'Odoo Community Association (OCA)',

--- a/account_cash_discount_base/models/res_company.py
+++ b/account_cash_discount_base/models/res_company.py
@@ -18,6 +18,9 @@ class ResCompany(models.Model):
         compute='_compute_cash_discount_tax_adjustment',
         store=True,
     )
+    cash_discount_allow_manual = fields.Boolean(
+        string='Allow manual cash discount',
+    )
 
     @api.model
     def _get_cash_discount_base_amount_types(self):

--- a/account_cash_discount_base/tests/test_account_cash_discount_base.py
+++ b/account_cash_discount_base/tests/test_account_cash_discount_base.py
@@ -117,3 +117,20 @@ class TestAccountCashDiscountBase(TestAccountCashDiscountCommon):
         self.assertEqual(
             invoice.discount_delay,
             payment_term.discount_delay)
+
+    def test_compute_discount_manual(self):
+        self.company.cash_discount_allow_manual = True
+        invoice = self.create_simple_invoice(1000)
+
+        invoice.discount_percent = 0
+        self.assertEqual(invoice.discount_amount, 0)
+        self.assertEqual(invoice.amount_total_with_discount, 1100)
+
+        invoice.discount_percent = 10
+        self.assertEqual(invoice.discount_amount, 100)
+        self.assertEqual(invoice.amount_total_with_discount, 1000)
+
+        invoice.enable_manual_cash_discount = True
+        invoice.manual_cash_discount = 150
+        self.assertEqual(invoice.discount_amount, 150)
+        self.assertEqual(invoice.amount_total_with_discount, 950)

--- a/account_cash_discount_base/views/account_invoice.xml
+++ b/account_cash_discount_base/views/account_invoice.xml
@@ -13,6 +13,11 @@
             <xpath expr="//field[@name='journal_id']/parent::group/parent::group" position="inside">
                 <group string="Cash Discount" name="cash_discount"
                        attrs="{'invisible': [('type', 'not in', ('in_invoice', 'in_refund'))]}">
+                    <field name="company_cash_discount_allow_manual" invisible="1"/>
+                    <field name="enable_manual_cash_discount"
+                           attrs="{'invisible': [('company_cash_discount_allow_manual', '=', False)]}"/>
+                    <field name="manual_cash_discount"
+                           attrs="{'invisible': [('enable_manual_cash_discount', '=', False)]}"/>
                     <field name="discount_percent"/>
                     <field name="discount_amount"/>
                     <field name="amount_total_with_discount"/>

--- a/account_cash_discount_base/views/res_company.xml
+++ b/account_cash_discount_base/views/res_company.xml
@@ -14,6 +14,7 @@
             <xpath expr="//field[@name='partner_id']/parent::group/parent::group" position="inside">
                 <group name="cash_discount" string="Cash Discount">
                     <field name="cash_discount_base_amount_type" string="Base Amount Type"/>
+                    <field name="cash_discount_allow_manual"/>
                 </group>
             </xpath>
 


### PR DESCRIPTION
Adds a parameter on Company level to authorize or not the manual cash discount.
Adds a parameter on invoice level to enable manual discount field.
Adds the manual cash discount on invoice level.