### PR TITLE
[FIX] account_check_printing_report_base: invoice with multiple payments

### DIFF
--- a/account_check_printing_report_base/report/check_print.py
+++ b/account_check_printing_report_base/report/check_print.py
@@ -47,7 +47,10 @@ class ReportCheckPrint(models.AbstractModel):
                 if invoice.type == 'out_refund':
                     line['amount_total'] *= -1
                 total_amount_to_show = 0.0
-                for pay in invoice.payment_move_line_ids:
+                payment_move_lines = (
+                    invoice.payment_move_line_ids & payment.move_line_ids
+                )
+                for pay in payment_move_lines:
                     payment_currency_id = False
                     if invoice.type in ('out_invoice', 'in_refund'):
                         amount = sum(


### PR DESCRIPTION
Fix check printing to work with invoices that have multiple payments.
The amount in the "Payment" column should only include amounts related
to the selected payment.

Fixes #258.