### PR TITLE
[FIX]account_check_printing_report_base: Fix report printing Issue

### DIFF
--- a/account_check_printing_report_base/__manifest__.py
+++ b/account_check_printing_report_base/__manifest__.py
@@ -7,7 +7,7 @@
 
 {
     "name": "Account Check Printing Report Base",
-    "version": "11.0.1.2.0",
+    "version": "11.0.1.2.1",
     "license": "AGPL-3",
     "author": "Eficent,"
               "Serpent Consulting Services Pvt. Ltd.,"

--- a/account_check_printing_report_base/report/check_print.py
+++ b/account_check_printing_report_base/report/check_print.py
@@ -21,7 +21,8 @@ class ReportCheckPrint(models.AbstractModel):
 
     @api.multi
     def get_paid_lines(self, payments):
-        if self.env.context.get('active_model') != 'account.payment':
+        model = self.env.context.get('active_model')
+        if model and model != 'account.payment':
             return {}
         lines = {}
         for payment in payments:

--- a/account_check_printing_report_base/views/report_check_base.xml
+++ b/account_check_printing_report_base/views/report_check_base.xml
@@ -15,7 +15,7 @@
                         <span t-esc="o.payment_date"/>
                         <br/>
                         <span t-field="o.amount"
-                              t-options='{"widget": "monetary", "display_currency": "o.currency_id"}'/>
+                              t-options='{"widget": "monetary", "display_currency": o.currency_id}'/>
                         <br/>
                         <span t-esc="fill_stars(o.check_amount_in_words)"/>
                     </div>
@@ -30,52 +30,54 @@
                                 <span style="padding-right:60mm;float:right;"
                                       t-esc="o.payment_date"/>
                             </strong>
-                            <t t-foreach="range(2)" t-as="i">
-                                <table width="100%"
-                                       style="padding-right:22mm;">
-                                    <thead>
-                                        <tr style="text-align:left;">
-                                            <th style="padding-top:3mm;">Due
-                                                Date
-                                            </th>
-                                            <th>Description</th>
-                                            <th>Original Amount</th>
-                                            <th>Balance Due</th>
-                                            <th>Payment</th>
-                                        </tr>
-                                    </thead>
-                                    <tbody>
-                                        <t t-foreach="paid_lines[o.id]"
-                                           t-as="line">
-                                            <tr style="text-align:left;border-top: 0px;">
-                                                <td style="padding-top:3mm;">
-                                                    <span t-esc="line['date_due']"/>
-                                                </td>
-                                                <td>
-                                                    <span t-esc="line['reference'] or line['number']"/>
-                                                </td>
-                                                <td>
-                                                    <span t-esc="line['amount_total']"
-                                                          t-esc-options='{"widget": "monetary", "display_currency": "o.currency_id"}'/>
-                                                </td>
-                                                <td>
-                                                    <span t-esc="line['residual']"
-                                                          t-esc-options='{"widget": "monetary", "display_currency": "o.currency_id"}'/>
-                                                </td>
-                                                <td>
-                                                    <span t-esc="line['paid_amount']"
-                                                          t-esc-options='{"widget": "monetary", "display_currency": "o.currency_id"}'/>
-                                                </td>
+                            <t t-if="paid_lines">
+                                <t t-foreach="range(2)" t-as="i">
+                                    <table width="100%"
+                                           style="padding-right:22mm;">
+                                        <thead>
+                                            <tr style="text-align:left;">
+                                                <th style="padding-top:3mm;">Due
+                                                    Date
+                                                </th>
+                                                <th>Description</th>
+                                                <th>Original Amount</th>
+                                                <th>Balance Due</th>
+                                                <th>Payment</th>
                                             </tr>
-                                        </t>
-                                    </tbody>
-                                </table>
-                                <div style="padding-right:20mm;padding-top:45mm;padding-bottom:15mm;"
-                                     align="right">
-                                    <b>Check Amount:</b>
-                                    <span t-field="o.amount"
-                                          t-options='{"widget": "monetary", "display_currency": "o.currency_id"}'/>
-                                </div>
+                                        </thead>
+                                        <tbody>
+                                            <t t-foreach="paid_lines[o.id]"
+                                               t-as="line">
+                                                <tr style="text-align:left;border-top: 0px;">
+                                                    <td style="padding-top:3mm;">
+                                                        <span t-esc="line['date_due']"/>
+                                                    </td>
+                                                    <td>
+                                                        <span t-esc="line['reference'] or line['number']"/>
+                                                    </td>
+                                                    <td>
+                                                        <span t-esc="line['amount_total']"
+                                                              t-esc-options='{"widget": "monetary", "display_currency": o.currency_id}'/>
+                                                    </td>
+                                                    <td>
+                                                        <span t-esc="line['residual']"
+                                                              t-esc-options='{"widget": "monetary", "display_currency": o.currency_id}'/>
+                                                    </td>
+                                                    <td>
+                                                        <span t-esc="line['paid_amount']"
+                                                              t-esc-options='{"widget": "monetary", "display_currency": o.currency_id}'/>
+                                                    </td>
+                                                </tr>
+                                            </t>
+                                        </tbody>
+                                    </table>
+                                    <div style="padding-right:20mm;padding-top:45mm;padding-bottom:15mm;"
+                                         align="right">
+                                        <b>Check Amount:</b>
+                                        <span t-field="o.amount"
+                                              t-options='{"widget": "monetary", "display_currency": o.currency_id}'/>
+                                    </div>
+                                </t>
                             </t>
                         </div>
                     </div>


### PR DESCRIPTION
Followup on https://github.com/OCA/account-payment/commit/af65135a16fe11268ecf28181a6ef4cbde49832c

Fixes https://github.com/OCA/account-payment/issues/230


**Changes made**

- Since `active_model` is not available on `report_action`'s `context` we should print the report if there is no  `active_model` in context (See https://github.com/odoo/odoo/issues/7959 and https://stackoverflow.com/questions/40305963/passing-data-with-context-to-abstractmodel-odoo)
- Don't try print if there are no `paid_lines`
- Fix `odoo.addons.base.ir.ir_qweb.ir_qweb: Use new syntax for 'b'<span t-tag="span"/>\n '' monetary widget t-options (python dict instead of deprecated JSON syntax).`


(Ps: should fix the issue in https://github.com/OCA/l10n-usa/pull/31#issuecomment-495867371)