### PR TITLE
[12.0] [IMP] Payment Return Import ISO 20022: manage multiple notification, entry and details nodes

### DIFF
--- a/account_payment_return_import_iso20022/__manifest__.py
+++ b/account_payment_return_import_iso20022/__manifest__.py
@@ -6,7 +6,7 @@
     'summary': """
         This addon allows to import payment returns from ISO 20022 files
         like PAIN or CAMT.""",
-    'version': '12.0.1.0.0',
+    'version': '12.0.1.0.1',
     'development_status': 'Production/Stable',
     'license': 'AGPL-3',
     'author': 'Odoo Community Association (OCA),Tecnativa,ACSONE SA/NV',

--- a/account_payment_return_import_iso20022/test_files/test-sepa-camt-unpaid-invalid.xml
+++ b/account_payment_return_import_iso20022/test_files/test-sepa-camt-unpaid-invalid.xml
@@ -55,6 +55,11 @@
                             <EndToEndId>E2EID1</EndToEndId>
                             <MndtId>MANDATEID2</MndtId>
                         </Refs>
+                        <AmtDtls>
+                            <InstdAmt>
+                                <Amt Ccy="EUR">100.00</Amt>
+                            </InstdAmt>
+                        </AmtDtls>
                         <RltdPties>
                             <Dbtr>
                                 <Nm>DEBTOR4</Nm>

--- a/account_payment_return_import_iso20022/test_files/test-sepa-camt-unpaid.xml
+++ b/account_payment_return_import_iso20022/test_files/test-sepa-camt-unpaid.xml
@@ -55,6 +55,11 @@
                             <EndToEndId>E2EID1</EndToEndId>
                             <MndtId>MANDATEID2</MndtId>
                         </Refs>
+                        <AmtDtls>
+                            <InstdAmt>
+                                <Amt Ccy="EUR">100.00</Amt>
+                            </InstdAmt>
+                        </AmtDtls>
                         <RltdPties>
                             <Dbtr>
                                 <Nm>DEBTOR4</Nm>

--- a/account_payment_return_import_iso20022/tests/test_import_iso20022.py
+++ b/account_payment_return_import_iso20022/tests/test_import_iso20022.py
@@ -86,7 +86,7 @@ class TestImport(TestPaymentReturnFile):
         self._test_return_import(
             'account_payment_return_import_iso20022',
             'test-sepa-camt-unpaid.xml',
-            'MSGID99345678912',
+            'ZY08XXXXXXIS634C',
             local_account='NL77ABNA0574908765',
             date='2016-10-08', transactions=transactions
         )
@@ -103,7 +103,7 @@ class TestImport(TestPaymentReturnFile):
             self._test_return_import(
                 'account_payment_return_import_iso20022',
                 'test-sepa-camt-unpaid-invalid.xml',
-                'MSGID99345678912',
+                'ZY08XXXXXXIS634C',
                 local_account='NL77ABNA0574908765',
                 date='2016-10-08', transactions=transactions
             )
@@ -113,7 +113,7 @@ class TestImport(TestPaymentReturnFile):
         self._test_return_import(
             'account_payment_return_import_iso20022',
             'test-sepa-camt-unpaid.zip',
-            'MSGID99345678912',
+            'ZY08XXXXXXIS634C',
             local_account='NL77ABNA0574908765',
             date='2016-10-08'
         )


### PR DESCRIPTION
There may be more than one details node in a single entry node.
They must create one return line each.
The return amount must be taken in the details node instead of the entry node.