### PR TITLE
[12.0][FIX] account_check_printing_report_base: Report format

### DIFF
--- a/account_check_printing_report_base/views/report_check_base.xml
+++ b/account_check_printing_report_base/views/report_check_base.xml
@@ -5,84 +5,80 @@
         <t t-call="web.html_container">
             <div class="header"/>
             <div class="article">
-            <t t-foreach="docs" t-as="o">
-                <div class="page">
-                    <div class="row">
-                    <div style="padding-top:20mm;">
-                        <address t-field="o.partner_id"
-                                 t-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": true, "no_tag_br": true}'/>
+                <t t-foreach="docs" t-as="o">
+                    <div class="page">
+                        <div class="oe_structure"/>
+                        <div class="row mb32 mt32" style="padding-top: 20mm;">
+                            <div class="col-8">
+                                <address t-field="o.partner_id"
+                                         t-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": true, "no_tag_br": true}'/>
 
-                        <span t-esc="o.payment_date"/>
-                        <br/>
-                        <span t-field="o.amount"
-                              t-options='{"widget": "monetary", "display_currency": o.currency_id}'/>
-                        <br/>
-                        <span t-esc="fill_stars(o.check_amount_in_words)"/>
-                    </div>
-                    <br/>
-                    <br/>
-                    <br/>
-                    <br/>
-                    <div>
-                        <div>
-                            <strong>
-                                <span t-field="o.partner_id.name"/>
-                                <span style="padding-right:60mm;float:right;"
-                                      t-esc="o.payment_date"/>
-                            </strong>
-                            <t t-foreach="range(2)" t-as="i">
-                                <table width="100%"
-                                       style="padding-right:22mm;">
-                                    <thead>
-                                        <tr style="text-align:left;">
-                                            <th style="padding-top:3mm;">Due
-                                                Date
-                                            </th>
-                                            <th>Description</th>
-                                            <th>Original Amount</th>
-                                            <th>Balance Due</th>
-                                            <th>Payment</th>
-                                        </tr>
-                                    </thead>
-                                    <tbody>
-                                        <t t-foreach="paid_lines[o.id]"
-                                           t-as="line">
-                                            <tr style="text-align:left;border-top: 0px;">
-                                                <td style="padding-top:3mm;">
-                                                    <span t-esc="line['date_due']"/>
-                                                </td>
-                                                <td>
-                                                    <span t-esc="line['reference'] or line['number']"/>
-                                                </td>
-                                                <td>
-                                                    <span t-esc="line['amount_total']"
-                                                          t-esc-options='{"widget": "monetary", "display_currency": o.currency_id}'/>
-                                                </td>
-                                                <td>
-                                                    <span t-esc="line['residual']"
-                                                          t-esc-options='{"widget": "monetary", "display_currency": o.currency_id}'/>
-                                                </td>
-                                                <td>
-                                                    <span t-esc="line['paid_amount']"
-                                                          t-esc-options='{"widget": "monetary", "display_currency": o.currency_id}'/>
-                                                </td>
-                                            </tr>
-                                        </t>
-                                    </tbody>
-                                </table>
-                                <div style="padding-right:20mm;padding-top:45mm;padding-bottom:15mm;"
-                                     align="right">
-                                    <b>Check Amount:</b>
-                                    <span t-field="o.amount"
-                                          t-options='{"widget": "monetary", "display_currency": o.currency_id}'/>
-                                </div>
-                            </t>
+                                <span t-esc="o.payment_date"/>
+                                <br/>
+                                <span t-field="o.amount"
+                                      t-options='{"widget": "monetary", "display_currency": o.currency_id}'/>
+                                <br/>
+                                <span t-esc="fill_stars(o.check_amount_in_words)"/>
+                            </div>
                         </div>
+                        <br/>
+                        <br/>
+                        <br/>
+                        <br/>
+                        <div class="row">
+                            <div class="col-8">
+                                <strong t-field="o.partner_id.name"/>
+                            </div>
+                            <div class="col-4">
+                                <strong t-field="o.payment_date"/>
+                            </div>
+                        </div>
+                        <t t-foreach="range(2)" t-as="i">
+                            <table class="table table-sm table-borderless">
+                                <thead>
+                                    <tr>
+                                        <th>Due Date</th>
+                                        <th>Description</th>
+                                        <th>Original Amount</th>
+                                        <th>Balance Due</th>
+                                        <th>Payment</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <t t-foreach="paid_lines[o.id]" t-as="line">
+                                        <tr>
+                                            <td>
+                                                <span t-esc="line['date_due']"/>
+                                            </td>
+                                            <td>
+                                                <span t-esc="line['reference'] or line['number']"/>
+                                            </td>
+                                            <td>
+                                                <span t-esc="line['amount_total']"
+                                                      t-options='{"widget": "monetary", "display_currency": o.currency_id}'/>
+                                            </td>
+                                            <td>
+                                                <span t-esc="line['residual']"
+                                                      t-options='{"widget": "monetary", "display_currency": o.currency_id}'/>
+                                            </td>
+                                            <td>
+                                                <span t-esc="line['paid_amount']"
+                                                      t-options='{"widget": "monetary", "display_currency": o.currency_id}'/>
+                                            </td>
+                                        </tr>
+                                    </t>
+                                </tbody>
+                            </table>
+                            <div style="padding-right: 20mm; padding-top: 45mm; padding-bottom: 15mm;"
+                                 align="right">
+                                <b>Check Amount:</b>
+                                <span t-field="o.amount"
+                                      t-options='{"widget": "monetary", "display_currency": o.currency_id}'/>
+                            </div>
+                        </t>
                     </div>
-                </div>
-                </div>
-                <p style="page-break-before:always;"> </p>
-            </t>
+                    <p style="page-break-before:always;"></p>
+                </t>
             </div>
         </t>
     </template>


### PR DESCRIPTION
As @aheficent says in https://github.com/OCA/account-payment/pull/241#issuecomment-502039004 the report is displaying bad.

Before changes:
![old_report](https://user-images.githubusercontent.com/5578568/62304929-400dc000-b47f-11e9-865a-22f066385868.png)

After changes:
![now_report](https://user-images.githubusercontent.com/5578568/62304951-4c921880-b47f-11e9-90d9-41fa18ea4d50.png)
