### PR TITLE
[FIX] account_payment_extension: Lower sequence

### DIFF
--- a/account_payment_extension/__openerp__.py
+++ b/account_payment_extension/__openerp__.py
@@ -15,4 +15,5 @@
     'data': [
     ],
     'installable': True,
+    'sequence': 50,
 }


### PR DESCRIPTION
If this module is migrated after i.e. `account_banking_payment_export`, the migration will fail.

Lowering the sequence (which [usually defaults to 100][1]) will help this module be migrated before, always.

[1]: https://github.com/OCA/OCB/blob/21eddc05a5cdd1709daf2038498077fa542d9cf2/openerp/modules/module.py#L242

@Tecnativa TT18838