### PR TITLE
[12.0] ADD account_payment_select_cost_account

### DIFF
--- a/account_payment_select_cost_account/__init__.py
+++ b/account_payment_select_cost_account/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/account_payment_select_cost_account/__manifest__.py
+++ b/account_payment_select_cost_account/__manifest__.py
@@ -1,0 +1,22 @@
+# Copyright 2019 Lorenzo Battistini
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
+
+{
+    "name": "Outbound payments: select account",
+    "summary": "Allow user to select the account where journal item will be recorded",
+    "version": "12.0.1.0.0",
+    "development_status": "Beta",
+    "category": "Invoicing Management",
+    "website": "https://github.com/OCA/account-payment",
+    "author": "TAKOBI, Odoo Community Association (OCA)",
+    "maintainers": ["eLBati"],
+    "license": "LGPL-3",
+    "application": False,
+    "installable": True,
+    "depends": [
+        "account",
+    ],
+    "data": [
+        "views/account_payment_view.xml"
+    ],
+}

--- a/account_payment_select_cost_account/models/__init__.py
+++ b/account_payment_select_cost_account/models/__init__.py
@@ -1,0 +1,1 @@
+from . import account_payment

--- a/account_payment_select_cost_account/models/account_payment.py
+++ b/account_payment_select_cost_account/models/account_payment.py
@@ -1,0 +1,18 @@
+from odoo import models, fields, api
+
+
+class Payment(models.Model):
+    _inherit = 'account.payment'
+    force_destination_account_id = fields.Many2one(
+        'account.account', string="Cost account")
+
+    @api.onchange("destination_account_id")
+    def onchange_destination_account_id(self):
+        if self.destination_account_id:
+            self.force_destination_account_id = self.destination_account_id.id
+
+    def _get_counterpart_move_line_vals(self, invoice=False):
+        vals = super(Payment, self)._get_counterpart_move_line_vals(invoice)
+        if self.force_destination_account_id:
+            vals['account_id'] = self.force_destination_account_id.id
+        return vals

--- a/account_payment_select_cost_account/readme/CONTRIBUTORS.rst
+++ b/account_payment_select_cost_account/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Lorenzo Battistini

--- a/account_payment_select_cost_account/readme/CREDITS.rst
+++ b/account_payment_select_cost_account/readme/CREDITS.rst
@@ -1,0 +1,3 @@
+The development of this module has been financially supported by:
+
+* TAKOBI https://takobi.online

--- a/account_payment_select_cost_account/readme/DESCRIPTION.rst
+++ b/account_payment_select_cost_account/readme/DESCRIPTION.rst
@@ -1,0 +1,6 @@
+The module allows users to specify which account to use in outbound payments.
+
+Without this module, you can only use a payable account, not being able to use a cost account.
+
+This is useful when you need to track payment status, also attaching files and chatting, for payments not tracked by other documents, like fiscal payments,
+penalties, etc.

--- a/account_payment_select_cost_account/readme/USAGE.rst
+++ b/account_payment_select_cost_account/readme/USAGE.rst
@@ -1,0 +1,2 @@
+Just select "Cost account" in vendors payments
+

--- a/account_payment_select_cost_account/tests/__init__.py
+++ b/account_payment_select_cost_account/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_account_payment_select_cost_account

--- a/account_payment_select_cost_account/tests/test_account_payment_select_cost_account.py
+++ b/account_payment_select_cost_account/tests/test_account_payment_select_cost_account.py
@@ -1,0 +1,29 @@
+from odoo.tests.common import TransactionCase
+
+
+class TestPaymentSelectCost(TransactionCase):
+
+    def setUp(self):
+        super(TestPaymentSelectCost, self).setUp()
+        self.account_cost = self.env['account.account'].search([
+            ('user_type_id', '=', self.env.ref('account.data_account_type_expenses').id)
+        ], limit=1)
+        self.bank_journal = self.env['account.journal'].create(
+            {'name': 'Bank', 'type': 'bank', 'code': 'BNK'})
+
+    def test_outbound_payment(self):
+        payment = self.env['account.payment'].create({
+            'payment_type': 'outbound',
+            'partner_type': 'supplier',
+            'journal_id': self.bank_journal.id,
+            'payment_method_id': self.bank_journal.outbound_payment_method_ids[0].id,
+            'amount': 100,
+        })
+        payment.onchange_destination_account_id()
+        payment._convert_to_write(payment._cache)
+        payment.force_destination_account_id = self.account_cost.id
+        payment.post()
+        self.assertEqual(len(payment.move_line_ids), 2)
+        for line in payment.move_line_ids:
+            if line.debit:
+                self.assertEqual(line.account_id.id, self.account_cost.id)

--- a/account_payment_select_cost_account/views/account_payment_view.xml
+++ b/account_payment_select_cost_account/views/account_payment_view.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_account_payment_form_select_account" model="ir.ui.view">
+        <field name="name">view_account_payment_form_select_account</field>
+        <field name="model">account.payment</field>
+        <field name="inherit_id" ref="account.view_account_payment_form"/>
+        <field name="arch" type="xml">
+            <field name="partner_id" position="after">
+                <field name="destination_account_id" invisible="1"/>
+                <field name="force_destination_account_id"
+                       attrs="{'required': [('state', '=', 'draft'), ('payment_type', 'in', ('outbound'))], 'invisible': [('payment_type', 'not in', ('outbound'))], 'readonly': [('state', '!=', 'draft')]}"/>
+            </field>
+        </field>
+    </record>
+</odoo>

--- a/setup/account_payment_select_cost_account/odoo/addons/account_payment_select_cost_account
+++ b/setup/account_payment_select_cost_account/odoo/addons/account_payment_select_cost_account
@@ -1,0 +1,1 @@
+../../../../account_payment_select_cost_account

--- a/setup/account_payment_select_cost_account/setup.py
+++ b/setup/account_payment_select_cost_account/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
The module allows users to specify which account to use in outbound payments.
Without this module, you can only use a payable account, not being able to use a cost account.
This is useful when you need to track payment status, also attaching files and chatting, for payments not tracked by other documents, like fiscal payments,
penalties, etc.