### PR TITLE
11.0 Extends payment returns to support supplier invoices

### DIFF
--- a/account_payment_return/README.rst
+++ b/account_payment_return/README.rst
@@ -3,10 +3,10 @@
    :alt: License: AGPL-3
 
 =================================
-Returned Customers Payment Orders
+Returned Payment Orders
 =================================
 
-This module implements customer receivables returns and allows to send
+This module implements receivables returns and allows to send
 related reconciled account move lines back to a state where the debt is still
 open, and letting history of it.
 
@@ -16,7 +16,7 @@ full returned payment record.
 Usage
 =====
 
-#. Go to Invoicing > Sales > Customer Payment Returns, and create a new
+#. Go to Invoicing > Payments > Payment Returns, and create a new
    record, register on each line a paid (reconciled) receivable journal item,
    and input the amount that is going to be returned.
 
@@ -58,6 +58,7 @@ Contributors
 * Carlos Dauden <carlos.dauden@tecnativa.com>
 * David Vidal <david.vidal@tecnativa.com>
 * Luis M. Ontalba <luis.martinez@tecnativa.com>
+* Benoît Schopfer <bschopfer@compassion.ch>
 
 Maintainer
 ----------

--- a/account_payment_return/README.rst
+++ b/account_payment_return/README.rst
@@ -6,8 +6,7 @@
 Returned Payment Orders
 =================================
 
-This module implements receivables returns and allows to send
-related reconciled account move lines back to a state where the debt is still
+This module implements customer receivables returns and vendor payable returns allows to send related reconciled account move lines back to a state where the debt is still
 open, and letting history of it.
 
 This module can be extended adding importers that automatically fills the
@@ -17,12 +16,14 @@ Usage
 =====
 
 #. Go to Invoicing > Payments > Payment Returns, and create a new
-   record, register on each line a paid (reconciled) receivable journal item,
+   record, register on each line a paid (reconciled) receivable/payable journal item,
    and input the amount that is going to be returned.
 
    Another option to fill info is setting references and click match button to
    find matches with invoices, move lines or moves. This functionality is extended
    by other modules as *account_payment_return_import_sepa_pain*
+
+   When using the return from a payment/debit order, if the payment mode generate offsetting moves with a transfert account, a transfert return journal has to be created.
 
 #. It's possible to add bank charges amount on each line.
 

--- a/account_payment_return/__manifest__.py
+++ b/account_payment_return/__manifest__.py
@@ -10,25 +10,28 @@
 
 {
     "name": "Account Payment Returns",
-    "version": "11.0.1.0.0",
+    "version": "11.0.2.0.0",
     "summary": "Manage the return of your payments",
     'license': 'AGPL-3',
     "depends": [
         'mail',
         'account',
+        'account_payment_order'
     ],
     'author': '7 i TRIA, '
               'Tecnativa, '
               'initOS GmbH & Co., '
+              'Compassion CH, '
               'Odoo Community Association (OCA)',
     'website': 'https://www.tecnativa.com',
     'data': [
         'security/ir.model.access.csv',
         'security/account_payment_return_security.xml',
+        'data/ir_sequence_data.xml',
         'views/payment_return_view.xml',
         'views/account_journal_view.xml',
-        'data/ir_sequence_data.xml',
         'views/account_invoice_view.xml',
+        'views/account_payment_line.xml',
     ],
     'qweb': [
         "static/src/xml/account_payment.xml",

--- a/account_payment_return/models/__init__.py
+++ b/account_payment_return/models/__init__.py
@@ -5,3 +5,4 @@ from . import account_invoice
 from . import payment_return_reason
 from . import account_move
 from . import account_journal
+from . import account_payment_line

--- a/account_payment_return/models/account_payment_line.py
+++ b/account_payment_return/models/account_payment_line.py
@@ -1,0 +1,16 @@
+# © 2015-2016 Akretion - Alexis de Lattre <alexis.delattre@akretion.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from odoo import fields, models
+
+
+class AccountPaymentLine(models.Model):
+    _inherit = 'account.payment.line'
+
+    returned_move_line_id = fields.Many2one(
+        'account.move.line', string='Returned Journal Item',
+        ondelete='restrict')
+
+    payment_line_returned = fields.Boolean(
+        string='Returned',
+        help='True if this payment line has been returned.')

--- a/account_payment_return/models/payment_return.py
+++ b/account_payment_return/models/payment_return.py
@@ -149,10 +149,10 @@ class PaymentReturn(models.Model):
             move_amount = self._get_move_amount(return_line)
             debit = 0.0
             credit = 0.0
-            if payment_order.payment_type == 'inbound':
-                debit = move_amount
-            else:
+            if payment_order.payment_type == 'outbound':
                 credit = move_amount
+            else:
+                debit = move_amount
             move_line2 = self.env['account.move.line'].with_context(
                 check_move_validity=False).create(
                 {
@@ -165,14 +165,31 @@ class PaymentReturn(models.Model):
                     'journal_id': move.journal_id.id,
                 })
             total_amount += move_amount
-            for move_line in return_line.move_line_ids:
-                returned_moves = move_line.matched_debit_ids.mapped(
-                    'debit_move_id')
-                invoices |= returned_moves.mapped('invoice_id')
-                move_line.remove_move_reconcile()
-                (move_line | move_line2).reconcile()
-                return_line.move_line_ids.mapped('matched_debit_ids').write(
-                    {'origin_returned_move_ids': [(6, 0, returned_moves.ids)]})
+
+            if payment_order.payment_type == 'outbound':
+                for move_line in return_line.move_line_ids:
+                    returned_moves = move_line.matched_credit_ids.mapped(
+                        'credit_move_id')
+                    invoices |= returned_moves.mapped('invoice_id')
+                    move_line.remove_move_reconcile()
+                    (move_line | move_line2).reconcile()
+                    return_line.move_line_ids.mapped(
+                        'matched_credit_ids').write(
+                        {
+                            'origin_returned_move_ids': [
+                                (6, 0, returned_moves.ids)]})
+            else:
+                for move_line in return_line.move_line_ids:
+                    returned_moves = move_line.matched_debit_ids.mapped(
+                        'debit_move_id')
+                    invoices |= returned_moves.mapped('invoice_id')
+                    move_line.remove_move_reconcile()
+                    (move_line | move_line2).reconcile()
+                    return_line.move_line_ids.mapped(
+                        'matched_debit_ids').write(
+                        {
+                            'origin_returned_move_ids': [
+                                (6, 0, returned_moves.ids)]})
             if return_line.expense_amount:
                 expense_lines_vals = []
                 expense_lines_vals.append({
@@ -201,10 +218,10 @@ class PaymentReturn(models.Model):
 
         credit = 0.0
         debit = 0.0
-        if payment_order.payment_type == 'inbound':
-            credit = total_amount
-        else:
+        if payment_order.payment_type == 'outbound':
             debit = total_amount
+        else:
+            credit = total_amount
         move_line_obj.create({
             'name': move.ref,
             'debit': debit,
@@ -223,8 +240,9 @@ class PaymentReturn(models.Model):
     @api.multi
     def action_cancel(self):
         invoices = self.env['account.invoice']
-        for move_line in self.mapped('move_id.line_ids').filtered(
-                lambda x: x.user_type_id.type == 'receivable'):
+        for move_line in self.mapped('move_id.line_ids')\
+                .filtered(lambda x: x.user_type_id.type == 'receivable'
+                          or x.user_type_id.type == 'payable'):
             for partial_line in move_line.matched_credit_ids:
                 invoices |= partial_line.origin_returned_move_ids.mapped(
                     'invoice_id')
@@ -232,6 +250,23 @@ class PaymentReturn(models.Model):
                                    partial_line.credit_move_id)
                 partial_line.credit_move_id.remove_move_reconcile()
                 lines2reconcile.reconcile()
+            for partial_line in move_line.matched_debit_ids:
+                invoices |= partial_line.origin_returned_move_ids.mapped(
+                    'invoice_id')
+                lines2reconcile = (partial_line.origin_returned_move_ids |
+                                   partial_line.debit_move_id)
+                partial_line.debit_move_id.remove_move_reconcile()
+                lines2reconcile.reconcile()
+        payment_order = self.env['account.payment.order'] \
+            .search([('bank_line_ids.name', '=', self.line_ids[0].reference)])
+        for return_line in self.line_ids:
+            payment_lines = payment_order.bank_line_ids \
+                .search([('name', '=', return_line.reference)]) \
+                .payment_line_ids
+            for pl in payment_lines:
+                pl.move_line_id = pl.returned_move_line_id
+                pl.returned_move_line_id = False
+                pl.payment_line_returned = False
         self.move_id.button_cancel()
         self.move_id.unlink()
         self.write({'state': 'cancelled', 'move_id': False})

--- a/account_payment_return/views/account_payment_line.xml
+++ b/account_payment_return/views/account_payment_line.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2017 Luis M. Ontalba <luis.martínez@tecnativa.com>
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl-3). -->
+<odoo>
+    <record id="account_payment_line_form" model="ir.ui.view">
+        <field name="name">account_payment_return.account.payment.line</field>
+        <field name="model">account.payment.line</field>
+        <field name="inherit_id" ref="account_payment_order.account_payment_line_form"/>
+        <field name="arch" type="xml">
+            <field name="move_line_id" position="after">
+                <field name="payment_line_returned" invisible="1"/>
+                <field name="returned_move_line_id"
+                       attr="{'invisible': [('payment_line_returned', '=', False)] "/>
+            </field>
+        </field>
+    </record>
+
+    <record id="account_payment_line_tree" model="ir.ui.view">
+        <field name="name">account_payment_return.account.payment.tree</field>
+        <field name="model">account.payment.line</field>
+        <field name="inherit_id" ref="account_payment_order.account_payment_line_tree"/>
+        <field name="arch" type="xml">
+            <field name="move_line_id" position="after">
+                <field name="payment_line_returned"/>
+            </field>
+        </field>
+    </record>
+</odoo>

--- a/account_payment_return/views/payment_return_view.xml
+++ b/account_payment_return/views/payment_return_view.xml
@@ -84,8 +84,8 @@
     </record>
 
     <menuitem id="payment_return_menu"
-              name="Customer Payment Returns"
-              parent="account.menu_finance_receivables"
+              name="Payment Returns"
+              parent="account_payment_order.payment_root"
               action="payment_return_action"
-              sequence="20"/>
+              sequence="70"/>
 </odoo>

--- a/account_payment_return_import/wizard/payment_return_import_view.xml
+++ b/account_payment_return_import/wizard/payment_return_import_view.xml
@@ -42,7 +42,7 @@
     </record>
 
     <menuitem id="menu_account_payment_return_import"
-              parent="account.menu_finance_receivables"
-              action="action_account_payment_return_import" sequence="22"/>
+              parent="account_payment_order.payment_root"
+              action="action_account_payment_return_import" sequence="60"/>
 
 </odoo>


### PR DESCRIPTION
This extends the module `account_payment_return` so that it can handle as well payment returns from supplier invoices.

- It moves the "Customer Payment Returns" menu and rename it to "Payment Returns".
- It links the payment returns to the payment orders, for matching the returns with the original orders