### PR TITLE
[12.0] [ADD] Payment return block move_lines

### DIFF
--- a/account_payment_return/__manifest__.py
+++ b/account_payment_return/__manifest__.py
@@ -29,6 +29,7 @@
         'views/account_journal_view.xml',
         'data/ir_sequence_data.xml',
         'views/account_invoice_view.xml',
+        'views/payment_return_reason.xml',
     ],
     'qweb': [
         "static/src/xml/account_payment.xml",

--- a/account_payment_return/models/account_move.py
+++ b/account_payment_return/models/account_move.py
@@ -28,3 +28,5 @@ class AccountMoveLine(models.Model):
     @api.multi
     def _payment_returned(self, return_line):
         self.mapped('invoice_id')._payment_returned(return_line)
+        if return_line.reason_id.block_move_lines:
+            self.write({"blocked": True})

--- a/account_payment_return/models/payment_return_reason.py
+++ b/account_payment_return/models/payment_return_reason.py
@@ -10,6 +10,11 @@ class PaymentReturnReason(models.Model):
 
     code = fields.Char()
     name = fields.Char(string='Reason', translate=True)
+    block_move_lines = fields.Boolean(
+        company_dependent=True,
+        help="Check 'No Follow-up' on journal items that used to be "
+             "reconciled with a payment returned with this code.",
+    )
 
     @api.model
     def name_search(self, name, args=None, operator='ilike', limit=100):

--- a/account_payment_return/views/payment_return_reason.xml
+++ b/account_payment_return/views/payment_return_reason.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2020 ACSONE SA/NV
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl-3). -->
+<odoo>
+    <record model="ir.ui.view" id="payment_return_reason_form_view">
+        <field name="model">payment.return.reason</field>
+        <field name="type">form</field>
+        <field name="arch" type="xml">
+            <form string="Payment return reason">
+                <group>
+                    <field name="code" required="True"/>
+                    <field name="name" required="True"/>
+                </group>
+            </form>
+        </field>
+    </record>
+
+    <record model="ir.ui.view" id="payment_return_reason_tree_view">
+        <field name="model">payment.return.reason</field>
+        <field name="type">tree</field>
+        <field name="arch" type="xml">
+            <tree string="Payment return reason">
+                <field name="code"/>
+                <field name="name"/>
+            </tree>
+        </field>
+    </record>
+
+    <record model="ir.ui.view" id="payment_return_reason_search_view">
+        <field name="model">payment.return.reason</field>
+        <field name="type">search</field>
+        <field name="arch" type="xml">
+            <search>
+                <field name="name" filter_domain="['|', ('code', 'ilike', self), ('name', 'ilike', self)]"/>
+            </search>
+        </field>
+    </record>
+
+    <record model="ir.actions.act_window" id="payment_return_reason_action">
+        <field name="name">Payment Return Reasons</field>
+        <field name="res_model">payment.return.reason</field>
+        <field name="view_type">form</field>
+        <field name="view_mode">tree,form</field>
+    </record>
+
+    <menuitem id="payment_return_reason_menu"
+              name="Payment Return Reasons"
+              parent="account.menu_finance_configuration"
+              action="payment_return_reason_action"/>
+</odoo>

--- a/account_payment_return/views/payment_return_reason.xml
+++ b/account_payment_return/views/payment_return_reason.xml
@@ -10,6 +10,7 @@
                 <group>
                     <field name="code" required="True"/>
                     <field name="name" required="True"/>
+                    <field name="block_move_lines"/>
                 </group>
             </form>
         </field>


### PR DESCRIPTION
based on https://github.com/OCA/account-payment/pull/310

Add an option on 'payment.return.reason' in order to block move_lines that were reconciled with a payment that has been returned.

Use case example:
You receive a return payment for a debit order with a certain code such that you know that trying a new debit will fail, blocking the move line prevents to retry.  