### PR TITLE
[12.0][FIX] - account-payment: fix unit tests

### DIFF
--- a/account_payment_multi_deduction/tests/test_payment_multi_deduction.py
+++ b/account_payment_multi_deduction/tests/test_payment_multi_deduction.py
@@ -96,6 +96,7 @@ class TestPaymentMultiDeduction(SavepointCase):
         view_id = ('account_payment_multi_deduction.'
                    'view_account_payment_from_invoices')
         with Form(PaymentWizard.with_context(ctx), view=view_id) as f:
+            f.group_invoices = True
             f.amount = 600.0  # Reduce to 600.0, and mark fully paid (multi)
             f.payment_difference_handling = 'reconcile_multi_deduct'
             with f.deduction_ids.new() as f2:

--- a/account_payment_show_invoice/tests/test_payment_ref_invoice.py
+++ b/account_payment_show_invoice/tests/test_payment_ref_invoice.py
@@ -59,6 +59,7 @@ class TestPaymentRefInvoice(TransactionCase):
             ctx).create({'payment_date': time.strftime('%Y-%m-%d'),
                          'journal_id': self.check_journal.id,
                          'payment_method_id': self.payment_method_manual_in.id,
+                         'group_invoices': True,
                          })
         register_payments.create_payments()
         payment = self.payment_model.search([], order="id desc", limit=1)


### PR DESCRIPTION
Fixes: #322 

There was a fix in `account_payment` module that changed the way how `multi` field is computed.
In the case of `test_2_two_invoices_register_payment` in `account_payment_multi_deduction` module,
it's evaluated to True and this made the payment registration `amount` field readonly.

https://github.com/odoo/odoo/blob/867de2bad3f6096098cb47611bcf0096b85e24b8/addons/account/models/account_payment.py#L303

Now, this operation raises an error.

https://github.com/OCA/account-payment/blob/4f7c56d8f501dde75a04f61076a27d2b011274c0/account_payment_multi_deduction/tests/test_payment_multi_deduction.py#L99

https://travis-ci.org/github/OCA/account-payment/jobs/658790207#L1020

multi=True caused this error too as the payment register is not grouping invoices.

https://travis-ci.org/github/OCA/account-payment/jobs/658790207#L1109

Setting `group_invoices` to True in the payment registration fixes the two tests