### PR TITLE
[FIX] account_cash_invoice : bad domain in xml view generate error in many journals context

### DIFF
--- a/account_cash_invoice/wizard/cash_invoice_in.xml
+++ b/account_cash_invoice/wizard/cash_invoice_in.xml
@@ -12,7 +12,7 @@
                     <field name="journal_count" invisible="1"/>
                     <field name="journal_id"
                            class="oe_inline"
-                           domain="[('id', 'in', journal_ids[0][2])]"
+                           domain="[('id', 'in', journal_ids)]"
                            options="{'no_create': True, 'no_open':True}"
                            attrs="{'invisible':[('journal_count', '&lt;', 2)]}"
                     />

--- a/account_cash_invoice/wizard/cash_invoice_out.xml
+++ b/account_cash_invoice/wizard/cash_invoice_out.xml
@@ -12,7 +12,7 @@
                     <field name="journal_count" invisible="1"/>
                     <field name="journal_id"
                            class="oe_inline"
-                           domain="[('id', 'in', journal_ids[0][2])]"
+                           domain="[('id', 'in', journal_ids)]"
                            options="{'no_create': True, 'no_open':True}"
                            attrs="{'invisible':[('journal_count', '&lt;', 2)]}"
                     />


### PR DESCRIPTION
trivial patch. 
there is an error if many journals are available. like for the module ``pos_session_pay_invoice`` available here : https://github.com/OCA/pos/pull/363

CC : @jarroyomorales , @kittiu, @etobella