### PR TITLE
[13.0][FIX] account_payment_return: moves canceling after latest changes on Odoo 13.0

### DIFF
--- a/account_payment_return/models/payment_return.py
+++ b/account_payment_return/models/payment_return.py
@@ -274,6 +274,7 @@ class PaymentReturn(models.Model):
                 )
                 partial_line.credit_move_id.remove_move_reconcile()
                 lines2reconcile.reconcile()
+        self.move_id.filtered(lambda move: move.state == "posted").button_draft()
         self.move_id.with_context(force_delete=True).unlink()
         self.write({"state": "cancelled", "move_id": False})
         invoices.check_payment_return()


### PR DESCRIPTION
Branch 13.0 seems broken: tests of `account_payment_return` are suddenly failing due to odoo/odoo#55088.
This PR fixes the broken branch by restoring the original behavior of `account_payment_return`.
