### PR TITLE
Adding path to activate Full Accounting Settings

### DIFF
--- a/account_due_list/readme/CONFIGURE.rst
+++ b/account_due_list/readme/CONFIGURE.rst
@@ -1,0 +1,3 @@
+To use this module, you need to :
+
+Go to Settings > Manage Access Rights > (Select your user) > Activate "Show Full Accounting Features"


### PR DESCRIPTION
Since the Runbot doesn't have Full Accounting Settings already activated, I think it's better to explain how to get it.