### PR TITLE
[12.0] [IMP] account_check_printing_report_base: Added a template to print checks in a4 documents

### DIFF
--- a/account_check_printing_report_base/README.rst
+++ b/account_check_printing_report_base/README.rst
@@ -33,13 +33,6 @@ layout.
 .. contents::
    :local:
 
-Installation
-============
-
-In order to install this module you must first install also the module
-'report_paper_wkhtmltopdf_params', available in
-https://github.com/OCA/server-tools
-
 Configuration
 =============
 
@@ -88,8 +81,11 @@ Contributors
 * Jordi Ballester Alomar <jordi.ballester@eficent.com>
 * Lois Rilo Antelo <lois.rilo@eficent.com>
 * Sandip Mangukiya <smangukiya@ursainfosystems.com>
-* Luis M. Ontalba <luis.martinez@tecnativa.com>
 * Manuel Marquez <mmarquez@iterativo.do>
+* `Tecnativa <https://www.tecnativa.com>`_:
+
+  * Luis M. Ontalba
+  * Carlos Roca
 
 Maintainers
 ~~~~~~~~~~~

--- a/account_check_printing_report_base/data/account_payment_check_report_data.xml
+++ b/account_check_printing_report_base/data/account_payment_check_report_data.xml
@@ -5,4 +5,9 @@
         <field name="name">Base</field>
         <field name="report">account_check_printing_report_base.report_check_base</field>
     </record>
+    <record id="account_payment_check_report_base_a4"
+            model="account.payment.check.report">
+        <field name="name">Base A4</field>
+        <field name="report">account_check_printing_report_base.report_check_base_a4</field>
+    </record>
 </odoo>

--- a/account_check_printing_report_base/data/report_paperformat_parameter.xml
+++ b/account_check_printing_report_base/data/report_paperformat_parameter.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<odoo>
-    <record id="paperformat_base_parameter_disable_smart_shrinking"
-            model="report.paperformat.parameter">
-        <field name="paperformat_id"
-               ref="account_check_printing_report_base.paperformat_check"/>
-        <field name="name">--disable-smart-shrinking</field>
-    </record>
-</odoo>

--- a/account_check_printing_report_base/i18n/account_check_printing_report_base.pot
+++ b/account_check_printing_report_base/i18n/account_check_printing_report_base.pot
@@ -6,6 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-09-28 06:13+0000\n"
+"PO-Revision-Date: 2020-09-28 06:13+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -88,6 +90,11 @@ msgstr ""
 #: model:ir.model.fields,field_description:account_check_printing_report_base.field_account_payment_check_report__display_name
 #: model:ir.model.fields,field_description:account_check_printing_report_base.field_report_account_check_printing_report_base_report_check_base__display_name
 msgid "Display Name"
+msgstr ""
+
+#. module: account_check_printing_report_base
+#: model_terms:ir.ui.view,arch_db:account_check_printing_report_base.report_check_base
+msgid "Invoice / Reference"
 msgstr ""
 
 #. module: account_check_printing_report_base

--- a/account_check_printing_report_base/i18n/es.po
+++ b/account_check_printing_report_base/i18n/es.po
@@ -4,26 +4,26 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 11.0\n"
+"Project-Id-Version: Odoo Server 12.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-02-23 04:29+0000\n"
-"PO-Revision-Date: 2019-02-23 04:29+0000\n"
-"Last-Translator: <>\n"
+"POT-Creation-Date: 2020-09-28 06:13+0000\n"
+"PO-Revision-Date: 2020-09-28 08:20+0200\n"
 "Language-Team: \n"
-"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
-"Plural-Forms: \n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 2.0.6\n"
+"Last-Translator: Carlos <carlos.roca@tecnativa.com>\n"
+"Language: es\n"
 
 #. module: account_check_printing_report_base
 #: model_terms:ir.ui.view,arch_db:account_check_printing_report_base.report_check_base
 msgid "<b>Check Amount:</b>"
-msgstr "<b>Monto del cheque:</b>"
+msgstr "<b>Cantidad:</b>"
 
 #. module: account_check_printing_report_base
 #: model:ir.model,name:account_check_printing_report_base.model_account_payment_check_report
-#, fuzzy
 msgid "Account Payment Check Report"
 msgstr "account.payment.check.report"
 
@@ -36,7 +36,7 @@ msgstr "Impresión de cheque automático"
 #. module: account_check_printing_report_base
 #: model_terms:ir.ui.view,arch_db:account_check_printing_report_base.report_check_base
 msgid "Balance Due"
-msgstr "Saldo adeudado"
+msgstr "Saldo a pagar"
 
 #. module: account_check_printing_report_base
 #: model_terms:ir.ui.view,arch_db:account_check_printing_report_base.account_payment_check_report_form
@@ -75,7 +75,7 @@ msgstr "Creado por"
 #. module: account_check_printing_report_base
 #: model:ir.model.fields,field_description:account_check_printing_report_base.field_account_payment_check_report__create_date
 msgid "Created on"
-msgstr "Creado en"
+msgstr "Creado el"
 
 #. module: account_check_printing_report_base
 #: model:ir.model.fields,help:account_check_printing_report_base.field_account_bank_statement_import_journal_creation__check_print_auto
@@ -96,18 +96,23 @@ msgstr "Descripción"
 #: model:ir.model.fields,field_description:account_check_printing_report_base.field_account_payment_check_report__display_name
 #: model:ir.model.fields,field_description:account_check_printing_report_base.field_report_account_check_printing_report_base_report_check_base__display_name
 msgid "Display Name"
-msgstr "Nombre mostrado"
+msgstr "Mostrar Nombre"
+
+#. module: account_check_printing_report_base
+#: model_terms:ir.ui.view,arch_db:account_check_printing_report_base.report_check_base
+msgid "Invoice / Reference"
+msgstr "Factura / Referencia"
 
 #. module: account_check_printing_report_base
 #: model_terms:ir.ui.view,arch_db:account_check_printing_report_base.report_check_base
 msgid "Due Date"
-msgstr ""
+msgstr "Fecha de Vencimiento"
 
 #. module: account_check_printing_report_base
 #: model:ir.model.fields,field_description:account_check_printing_report_base.field_account_payment_check_report__id
 #: model:ir.model.fields,field_description:account_check_printing_report_base.field_report_account_check_printing_report_base_report_check_base__id
 msgid "ID"
-msgstr "ID (identificación)"
+msgstr "ID"
 
 #. module: account_check_printing_report_base
 #: model:ir.model,name:account_check_printing_report_base.model_account_journal
@@ -123,12 +128,12 @@ msgstr "Última modificación en"
 #. module: account_check_printing_report_base
 #: model:ir.model.fields,field_description:account_check_printing_report_base.field_account_payment_check_report__write_uid
 msgid "Last Updated by"
-msgstr "Última actualización de"
+msgstr "Última actualización por"
 
 #. module: account_check_printing_report_base
 #: model:ir.model.fields,field_description:account_check_printing_report_base.field_account_payment_check_report__write_date
 msgid "Last Updated on"
-msgstr "Última actualización en"
+msgstr "Última actualización el"
 
 #. module: account_check_printing_report_base
 #: model:ir.model.fields,field_description:account_check_printing_report_base.field_account_payment_check_report__name
@@ -138,7 +143,7 @@ msgstr "Nombre"
 #. module: account_check_printing_report_base
 #: model_terms:ir.ui.view,arch_db:account_check_printing_report_base.report_check_base
 msgid "Original Amount"
-msgstr "Monto original"
+msgstr "Importe"
 
 #. module: account_check_printing_report_base
 #: model_terms:ir.ui.view,arch_db:account_check_printing_report_base.report_check_base
@@ -148,7 +153,7 @@ msgstr "Pago"
 #. module: account_check_printing_report_base
 #: model:ir.actions.report,name:account_check_printing_report_base.action_report_check_base
 msgid "Payment Check Base"
-msgstr "Cheque de Pago Base"
+msgstr "Cheque de pago Base"
 
 #. module: account_check_printing_report_base
 #: model:ir.model,name:account_check_printing_report_base.model_account_payment
@@ -157,32 +162,15 @@ msgstr "Pagos"
 
 #. module: account_check_printing_report_base
 #: model:ir.model,name:account_check_printing_report_base.model_account_register_payments
-#, fuzzy
 msgid "Register Payments"
-msgstr "Pagos"
+msgstr "Registrar pagos"
 
 #. module: account_check_printing_report_base
 #: model:ir.model,name:account_check_printing_report_base.model_report_account_check_printing_report_base_report_check_base
 msgid "Report Check Print"
-msgstr ""
+msgstr "Informe de impresión de cheques"
 
 #. module: account_check_printing_report_base
 #: model:ir.model.fields,field_description:account_check_printing_report_base.field_account_payment_check_report__report
 msgid "Report name"
 msgstr "Nombre del reporte"
-
-#~ msgid ""
-#~ "Due\n"
-#~ "                                                Date"
-#~ msgstr ""
-#~ "Fecha\n"
-#~ "                                                Vencimiento"
-
-#~ msgid "Register payments on multiple invoices"
-#~ msgstr "Registrar pagos en múltiples facturas"
-
-#~ msgid "You must define a check layout"
-#~ msgstr "You must define a check layout"
-
-#~ msgid "report.account_check_printing_report_base.report_check_base"
-#~ msgstr "report.account_check_printing_report_base.report_check_base"

--- a/account_check_printing_report_base/readme/CONTRIBUTORS.rst
+++ b/account_check_printing_report_base/readme/CONTRIBUTORS.rst
@@ -1,5 +1,8 @@
 * Jordi Ballester Alomar <jordi.ballester@eficent.com>
 * Lois Rilo Antelo <lois.rilo@eficent.com>
 * Sandip Mangukiya <smangukiya@ursainfosystems.com>
-* Luis M. Ontalba <luis.martinez@tecnativa.com>
 * Manuel Marquez <mmarquez@iterativo.do>
+* `Tecnativa <https://www.tecnativa.com>`_:
+
+  * Luis M. Ontalba
+  * Carlos Roca

--- a/account_check_printing_report_base/readme/INSTALL.rst
+++ b/account_check_printing_report_base/readme/INSTALL.rst
@@ -1,3 +1,0 @@
-In order to install this module you must first install also the module
-'report_paper_wkhtmltopdf_params', available in
-https://github.com/OCA/server-tools

--- a/account_check_printing_report_base/report/account_check_writing_report.xml
+++ b/account_check_printing_report_base/report/account_check_writing_report.xml
@@ -9,4 +9,12 @@
             report_type="qweb-pdf"
             paperformat="account_check_printing_report_base.paperformat_check"/>
 
+    <report id="action_report_check_base_a4"
+            string="Payment Check Base A4"
+            model="account.payment"
+            name="account_check_printing_report_base.report_check_base_a4"
+            file="account_check_printing_report_base.report_check_base_a4"
+            report_type="qweb-pdf"
+            paperformat="base.paperformat_euro"/>
+
 </odoo>

--- a/account_check_printing_report_base/report/check_print.py
+++ b/account_check_printing_report_base/report/check_print.py
@@ -113,3 +113,8 @@ class ReportCheckPrint(models.AbstractModel):
             '_format_date_to_partner_lang': self._format_date_to_partner_lang,
         }
         return docargs
+
+
+class ReportCheckPrintA4(models.AbstractModel):
+    _name = 'report.account_check_printing_report_base.report_check_base_a4'
+    _inherit = 'report.account_check_printing_report_base.report_check_base'

--- a/account_check_printing_report_base/static/description/index.html
+++ b/account_check_printing_report_base/static/description/index.html
@@ -373,34 +373,27 @@ layout.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
-<li><a class="reference internal" href="#installation" id="id1">Installation</a></li>
-<li><a class="reference internal" href="#configuration" id="id2">Configuration</a></li>
-<li><a class="reference internal" href="#usage" id="id3">Usage</a></li>
-<li><a class="reference internal" href="#known-issues-roadmap" id="id4">Known issues / Roadmap</a></li>
-<li><a class="reference internal" href="#bug-tracker" id="id5">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="id6">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="id7">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="id8">Contributors</a></li>
-<li><a class="reference internal" href="#maintainers" id="id9">Maintainers</a></li>
+<li><a class="reference internal" href="#configuration" id="id1">Configuration</a></li>
+<li><a class="reference internal" href="#usage" id="id2">Usage</a></li>
+<li><a class="reference internal" href="#known-issues-roadmap" id="id3">Known issues / Roadmap</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="id4">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="id5">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="id6">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="id7">Contributors</a></li>
+<li><a class="reference internal" href="#maintainers" id="id8">Maintainers</a></li>
 </ul>
 </li>
 </ul>
 </div>
-<div class="section" id="installation">
-<h1><a class="toc-backref" href="#id1">Installation</a></h1>
-<p>In order to install this module you must first install also the module
-‘report_paper_wkhtmltopdf_params’, available in
-<a class="reference external" href="https://github.com/OCA/server-tools">https://github.com/OCA/server-tools</a></p>
-</div>
 <div class="section" id="configuration">
-<h1><a class="toc-backref" href="#id2">Configuration</a></h1>
+<h1><a class="toc-backref" href="#id1">Configuration</a></h1>
 <p>Go to ‘Settings / Users / Companies’ and assign the desired check format.
 This module proposes a basic layout, but other modules such as
 “account_check_printing_report_dlt103” provide formats adjusted to known
 check formats such as DLT103.</p>
 </div>
 <div class="section" id="usage">
-<h1><a class="toc-backref" href="#id3">Usage</a></h1>
+<h1><a class="toc-backref" href="#id2">Usage</a></h1>
 <ul class="simple">
 <li>Go to ‘Invoicing / Purchases / Payments’. Select one of the payments with
 type ‘Check’ and print the check.</li>
@@ -409,14 +402,14 @@ the journal associated.</li>
 </ul>
 </div>
 <div class="section" id="known-issues-roadmap">
-<h1><a class="toc-backref" href="#id4">Known issues / Roadmap</a></h1>
+<h1><a class="toc-backref" href="#id3">Known issues / Roadmap</a></h1>
 <ul class="simple">
 <li>When print check automatically in the payment validation process, the wizard
 remains opened.</li>
 </ul>
 </div>
 <div class="section" id="bug-tracker">
-<h1><a class="toc-backref" href="#id5">Bug Tracker</a></h1>
+<h1><a class="toc-backref" href="#id4">Bug Tracker</a></h1>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/account-payment/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us smashing it by providing a detailed and welcomed
@@ -424,9 +417,9 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h1><a class="toc-backref" href="#id6">Credits</a></h1>
+<h1><a class="toc-backref" href="#id5">Credits</a></h1>
 <div class="section" id="authors">
-<h2><a class="toc-backref" href="#id7">Authors</a></h2>
+<h2><a class="toc-backref" href="#id6">Authors</a></h2>
 <ul class="simple">
 <li>Eficent</li>
 <li>Serpent Consulting Services Pvt. Ltd.</li>
@@ -434,17 +427,21 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 </ul>
 </div>
 <div class="section" id="contributors">
-<h2><a class="toc-backref" href="#id8">Contributors</a></h2>
+<h2><a class="toc-backref" href="#id7">Contributors</a></h2>
 <ul class="simple">
 <li>Jordi Ballester Alomar &lt;<a class="reference external" href="mailto:jordi.ballester&#64;eficent.com">jordi.ballester&#64;eficent.com</a>&gt;</li>
 <li>Lois Rilo Antelo &lt;<a class="reference external" href="mailto:lois.rilo&#64;eficent.com">lois.rilo&#64;eficent.com</a>&gt;</li>
 <li>Sandip Mangukiya &lt;<a class="reference external" href="mailto:smangukiya&#64;ursainfosystems.com">smangukiya&#64;ursainfosystems.com</a>&gt;</li>
-<li>Luis M. Ontalba &lt;<a class="reference external" href="mailto:luis.martinez&#64;tecnativa.com">luis.martinez&#64;tecnativa.com</a>&gt;</li>
 <li>Manuel Marquez &lt;<a class="reference external" href="mailto:mmarquez&#64;iterativo.do">mmarquez&#64;iterativo.do</a>&gt;</li>
+<li><a class="reference external" href="https://www.tecnativa.com">Tecnativa</a>:<ul>
+<li>Luis M. Ontalba</li>
+<li>Carlos Roca</li>
+</ul>
+</li>
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h2><a class="toc-backref" href="#id9">Maintainers</a></h2>
+<h2><a class="toc-backref" href="#id8">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
 <a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose

--- a/account_check_printing_report_base/views/report_check_base.xml
+++ b/account_check_printing_report_base/views/report_check_base.xml
@@ -83,4 +83,52 @@
         </t>
     </template>
 
+    <template id="report_check_base_a4">
+        <t t-call="web.html_container">
+            <t t-foreach="docs" t-as="o">
+                <t t-set="o" t-value="o.with_context(lang = o.partner_id.lang)" />
+                <t t-call="web.external_layout">
+                    <div class="page">
+                        <div id="check_body">
+                            <p>Dear partner</p>
+                            <p>
+                                We attach the list of invoices paid with this check with amount of
+                                <span t-field="o.amount" t-options="{'widget': 'monetary', 'display_currency': o.currency_id}" />
+                            </p>
+                            <div class="col-10 col-offset-2 mt32">
+                                <table class="table table-sm table-borderless">
+                                    <thead>
+                                        <tr>
+                                            <th>Invoice / Reference</th>
+                                            <th>Due Date</th>
+                                            <th class="text-right">Original Amount</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        <t t-foreach="paid_lines[o.id]" t-as="line">
+                                            <tr>
+                                                <td>
+                                                    <span t-esc="line['reference'] or line['number']" />
+                                                </td>
+                                                <td>
+                                                    <span t-esc="line['date_due']" />
+                                                </td>
+                                                <td class="text-right">
+                                                    <span t-esc="line['residual'] or line['amount_total']" t-options="{'widget': 'monetary', 'display_currency': o.currency_id}" />
+                                                </td>
+                                            </tr>
+                                        </t>
+                                    </tbody>
+                                </table>
+                            </div>
+                            <div class="row">
+                                <div class="col-12 mt64">Waiting for your agreement, regards.</div>
+                            </div>
+                        </div>
+                    </div>
+                </t>
+            </t>
+        </t>
+    </template>
+
 </odoo>


### PR DESCRIPTION
cc @Tecnativa this PR is necessary for TT18130

Please @pedrobaeza @carlosdauden can you review this

This improvement adds one template for print checks in format A4. This template have no info about the payment, this info will be added when we need to use that template.
![image](https://user-images.githubusercontent.com/35952655/94006733-92572200-fda0-11ea-9719-8a0a0973a919.png)

