### PR TITLE
[13.0][IMP] account_payment_term_extension, add option Days after weekend

### DIFF
--- a/account_payment_term_extension/demo/account_demo.xml
+++ b/account_payment_term_extension/demo/account_demo.xml
@@ -11,4 +11,13 @@
                       ]"
         />
     </record>
+    <record id="six_days_end_of_week" model="account.payment.term">
+        <field name="name">6 Days after next Saturday</field>
+        <field name="note">6 Days after next Saturday</field>
+        <field name="sequential_lines" eval="True" />
+        <field
+            name="line_ids"
+            eval="[(5, 0), (0,0, {'days': 6, 'option': 'day_after_next_weekday', 'week_end': '6', 'sequence': 10, 'value': 'balance', 'value_amount': 0})]"
+        />
+    </record>
 </odoo>

--- a/account_payment_term_extension/readme/CONTRIBUTORS.rst
+++ b/account_payment_term_extension/readme/CONTRIBUTORS.rst
@@ -11,3 +11,7 @@
 * `Domatix <https://domatix.com>`:
 
   * Carlos Martínez
+
+* `Ecosoft <http://ecosoft.co.th>`:
+
+  * Kitti U. <kittiu@ecosoft.co.th>

--- a/account_payment_term_extension/readme/DESCRIPTION.rst
+++ b/account_payment_term_extension/readme/DESCRIPTION.rst
@@ -1,5 +1,6 @@
 This module extends the functionality of payment terms to :
 
+* support payment term option, days after end of week
 * support rounding, months and weeks on payment term lines
 * allow to set more than one day of payment in payment terms
 * if a payment term date is a holiday, it is postponed to a selected date

--- a/account_payment_term_extension/tests/test_payment_term.py
+++ b/account_payment_term_extension/tests/test_payment_term.py
@@ -12,6 +12,9 @@ class TestAccountPaymentTerm(TransactionCase):
         self.sixty_days_end_of_month = self.env.ref(
             "account_payment_term_extension.sixty_days_end_of_month"
         )
+        self.six_days_end_of_week = self.env.ref(
+            "account_payment_term_extension.six_days_end_of_week"
+        )
         self.account_payment_term_holiday = self.env["account.payment.term.holiday"]
 
     def test_00_compute(self):
@@ -156,3 +159,16 @@ class TestAccountPaymentTerm(TransactionCase):
             self.account_payment_term_holiday.create(
                 {"holiday": "2015-06-07", "date_postponed": "2015-06-08"}
             )
+
+    def test_six_day_end_of_week(self):
+        """ When use lang with week_start = Sunday,
+        it will result in Friday (6th day of week) after this weekend """
+        # US is using Sunday as first day of week
+        res = self.six_days_end_of_week.compute(10, date_ref="2015-05-31")
+        self.assertEquals(res[0][0], "2015-06-12")
+        res = self.six_days_end_of_week.compute(10, date_ref="2015-06-02")
+        self.assertEquals(res[0][0], "2015-06-12")
+        res = self.six_days_end_of_week.compute(10, date_ref="2015-06-06")
+        self.assertEquals(res[0][0], "2015-06-12")
+        res = self.six_days_end_of_week.compute(10, date_ref="2015-06-07")
+        self.assertEquals(res[0][0], "2015-06-19")

--- a/account_payment_term_extension/views/account_payment_term.xml
+++ b/account_payment_term_extension/views/account_payment_term.xml
@@ -53,6 +53,13 @@
                 </div>
             </xpath>
             <field name="option" position="after">
+                <label for="week_end" string="" />
+                <!--Empty label to force space between elements-->
+                <field
+                    name="week_end"
+                    class="oe_inline"
+                    attrs="{'invisible': [('option', '!=', 'day_after_next_weekday')]}"
+                />
                 <br />
                 <label
                     for="weeks"


### PR DESCRIPTION
Add the new option, days after end of week, to support following scenario.

Given **Saturday** as last day of week,
* Document on this Sunday 1th, Mon, Tue, Wed, Thu, Fri, Saturday 7th, to set due on next Friday 13th

![image](https://user-images.githubusercontent.com/1973598/94520425-7814bc80-0256-11eb-81f8-013e7cede45c.png)

![image](https://user-images.githubusercontent.com/1973598/94520430-79de8000-0256-11eb-9144-53dd434e5d55.png)
