### PR TITLE
[13.0][IMP] account_payment_multi_deduction, ability to multi deduct with keep open

### DIFF
--- a/account_payment_multi_deduction/views/account_payment_view.xml
+++ b/account_payment_multi_deduction/views/account_payment_view.xml
@@ -30,7 +30,11 @@
                     >
                         <tree editable="bottom">
                             <field name="currency_id" invisible="1" />
-                            <field name="account_id" />
+                            <field name="open" />
+                            <field
+                                name="account_id"
+                                attrs="{'required': [('open', '=', False)]}"
+                            />
                             <field name="name" />
                             <field name="amount" sum="Total Deduction" />
                         </tree>


### PR DESCRIPTION
Currently there is no way to register payment with multiple deduction at the same time keep some amount open.

This PR, user can flag some line in deduction table, to keep some amount open. And that linke, i..e, 100.0 will be reduced from AR/AP account, in order to keep it open.

![image](https://user-images.githubusercontent.com/1973598/94990756-b852a280-05a8-11eb-87f5-186aac054df5.png)