### PR TITLE
[13.0][FIX] account_payment_term_extension missing standard option into ELIF part

### DIFF
--- a/account_payment_term_extension/models/account_payment_term.py
+++ b/account_payment_term_extension/models/account_payment_term.py
@@ -203,6 +203,12 @@ class AccountPaymentTerm(models.Model):
             elif line.option == "day_current_month":
                 # Getting last day of next month
                 next_date += relativedelta(day=line.days, months=0)
+            # From Odoo
+            elif line.option == "after_invoice_month":
+                # Getting 1st of next month
+                next_first_date = next_date + relativedelta(day=1, months=1)
+                # Then add days
+                next_date = next_first_date + relativedelta(days=line.days - 1)
             next_date = self.apply_payment_days(line, next_date)
             next_date = self.apply_holidays(next_date)
             if not float_is_zero(amt, precision_digits=precision_digits):


### PR DESCRIPTION
Fix module `account_payment_term_extension` who break the Odoo standard for the `after_invoice_month` option.

Of course, the option `day_following_month` is working perfectly for this case but with this option, you can not set more than than available into next month (29/29/30/31).
For example, if you have an invoice with date = 01/10/2020 and you set 15 days after the following month, the date due will be 15/11/2020 (OK).
But if you set 45 days after the following month, the date due will be 30/11/2020 (NOK).

In Odoo standard (standard's options still available even with this module installed), you have the option `after_invoice_month` who is completely ignored by this module.
With this option, you can set 45 days (to continue with my previous example) and the date due will be 15/12/2020 (OK).