### PR TITLE
[13.0][ADD] account_cash_discount_base add field discount_option

### DIFF
--- a/account_cash_discount_base/models/account_payment_term.py
+++ b/account_cash_discount_base/models/account_payment_term.py
@@ -10,3 +10,10 @@ class AccountPaymentTerm(models.Model):
 
     discount_percent = fields.Float(string="Discount (%)", digits="Discount",)
     discount_delay = fields.Integer(string="Discount Delay (days)")
+    discount_option = fields.Selection(
+        selection=[
+            ("day_after_invoice_date", "days after the invoice date"),
+            ("day_following_month", "of the following month"),
+        ],
+        default="day_after_invoice_date",
+    )

--- a/account_cash_discount_base/views/account_move.xml
+++ b/account_cash_discount_base/views/account_move.xml
@@ -18,6 +18,7 @@
                     <field name="discount_amount" />
                     <field name="amount_total_with_discount" />
                     <field name="discount_delay" />
+                    <field name="discount_option" />
                     <field name="discount_due_date" invisible="1" />
                     <field
                         name="discount_due_date_readonly"

--- a/account_cash_discount_base/views/account_payment_term.xml
+++ b/account_cash_discount_base/views/account_payment_term.xml
@@ -12,6 +12,7 @@
             <field name="active" position="after">
                 <field name="discount_percent" />
                 <field name="discount_delay" />
+                <field name="discount_option" />
             </field>
         </field>
     </record>


### PR DESCRIPTION
The goal is to set the `discount_due_date` based on the invoice `due_date` (default) or based on the next month (like the `due_date` could be computed).