### PR TITLE
[13.0][IMP] account_payment_promissory_note: Changes on due_date

### DIFF
--- a/account_payment_promissory_note/i18n/account_payment_promissory_note.pot
+++ b/account_payment_promissory_note/i18n/account_payment_promissory_note.pot
@@ -6,12 +6,22 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-11-18 14:51+0000\n"
+"PO-Revision-Date: 2020-11-18 14:51+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
+
+#. module: account_payment_promissory_note
+#: model_terms:ir.ui.view,arch_db:account_payment_promissory_note.view_account_payment_form_multi
+msgid ""
+"<span class=\"text-muted\" attrs=\"{'invisible': [('promissory_note','=', False)]}\">\n"
+"                    Set date due to all payments or empty to select last date due of each partner invoices group\n"
+"                </span>"
+msgstr ""
 
 #. module: account_payment_promissory_note
 #: model:ir.model.fields,field_description:account_payment_promissory_note.field_account_promissory_note_mixin__display_name

--- a/account_payment_promissory_note/i18n/es.po
+++ b/account_payment_promissory_note/i18n/es.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-10-14 08:53+0000\n"
-"PO-Revision-Date: 2020-10-14 10:55+0200\n"
+"POT-Creation-Date: 2020-11-18 14:51+0000\n"
+"PO-Revision-Date: 2020-11-18 15:55+0100\n"
 "Last-Translator: Carlos <carlos.roca@tecnativa.com>\n"
 "Language-Team: \n"
 "Language: es\n"
@@ -18,9 +18,25 @@ msgstr ""
 "X-Generator: Poedit 2.0.6\n"
 
 #. module: account_payment_promissory_note
+#: model_terms:ir.ui.view,arch_db:account_payment_promissory_note.view_account_payment_form_multi
+msgid ""
+"<span class=\"text-muted\" attrs=\"{'invisible': [('promissory_note','=', "
+"False)]}\">\n"
+"                    Set date due to all payments or empty to select last "
+"date due of each partner invoices group\n"
+"                </span>"
+msgstr ""
+"<span class=\"text-muted\" attrs=\"{'invisible': [('promissory_note','=', "
+"False)]}\">\n"
+"                   Selecciona una fecha de vencimiento para todos los pagos "
+"o dejalo vacío para que se seleccione la última fecha de vencimiento para "
+"cada agrupación de facturas de un partner.\n"
+"                </span>"
+
+#. module: account_payment_promissory_note
 #: model:ir.model.fields,field_description:account_payment_promissory_note.field_account_promissory_note_mixin__display_name
 msgid "Display Name"
-msgstr ""
+msgstr "Mostrar Nombre"
 
 #. module: account_payment_promissory_note
 #: model:ir.model.fields,field_description:account_payment_promissory_note.field_account_payment__date_due
@@ -32,12 +48,12 @@ msgstr "Fecha de Vencimiento"
 #. module: account_payment_promissory_note
 #: model:ir.model.fields,field_description:account_payment_promissory_note.field_account_promissory_note_mixin__id
 msgid "ID"
-msgstr ""
+msgstr "ID"
 
 #. module: account_payment_promissory_note
 #: model:ir.model.fields,field_description:account_payment_promissory_note.field_account_promissory_note_mixin____last_update
 msgid "Last Modified on"
-msgstr ""
+msgstr "Última modificación en"
 
 #. module: account_payment_promissory_note
 #: model:ir.model,name:account_payment_promissory_note.model_account_payment
@@ -60,7 +76,7 @@ msgstr ""
 #. module: account_payment_promissory_note
 #: model:ir.model,name:account_payment_promissory_note.model_account_payment_register
 msgid "Register Payment"
-msgstr ""
+msgstr "Registrar pago"
 
 #~ msgid ""
 #~ "Contains the logic shared between models which allows to register payments"

--- a/account_payment_promissory_note/models/account_payment.py
+++ b/account_payment_promissory_note/models/account_payment.py
@@ -25,5 +25,6 @@ class AccountPayment(models.Model):
         super()._onchange_promissory_note()
         if not self.date_due and self.promissory_note:
             invoices = self.invoice_ids
-            if invoices:
+            same_partner = len(invoices.mapped("partner_id")) == 1
+            if invoices and same_partner:
                 self.date_due = max(invoices.mapped("invoice_date_due"))

--- a/account_payment_promissory_note/views/account_payment_invoice_view.xml
+++ b/account_payment_promissory_note/views/account_payment_invoice_view.xml
@@ -10,6 +10,12 @@
                     name="date_due"
                     attrs="{'invisible': [('promissory_note','=', False)]}"
                 />
+                <span
+                    class="text-muted"
+                    attrs="{'invisible': [('promissory_note','=', False)]}"
+                >
+                    Set date due to all payments or empty to select last date due of each partner invoices group
+                </span>
             </xpath>
         </field>
     </record>

--- a/account_payment_promissory_note/wizard/account_register_payments.py
+++ b/account_payment_promissory_note/wizard/account_register_payments.py
@@ -10,11 +10,18 @@ class AccountRegisterPayments(models.TransientModel):
     _inherit = ["account.payment.register", "account.promissory.note.mixin"]
 
     def get_payments_vals(self):
-        vals = super(AccountRegisterPayments, self).get_payments_vals()
+        vals = super().get_payments_vals()
         for val in vals:
-            val.update(
-                {"promissory_note": self.promissory_note, "date_due": self.date_due}
-            )
+            if not self.date_due:
+                invoices = self.env["account.move"].browse(val["invoice_ids"][0][2])
+                max_date = max(invoices.mapped("invoice_date_due"))
+                val.update(
+                    {"promissory_note": self.promissory_note, "date_due": max_date}
+                )
+            else:
+                val.update(
+                    {"promissory_note": self.promissory_note, "date_due": self.date_due}
+                )
         return vals
 
     @api.onchange("promissory_note")
@@ -23,5 +30,6 @@ class AccountRegisterPayments(models.TransientModel):
         if not self.date_due and self.promissory_note:
             active_ids = self._context.get("active_ids")
             invoices = self.env["account.move"].browse(active_ids)
-            if invoices:
+            same_partner = len(invoices.mapped("partner_id")) == 1
+            if invoices and self.group_payment and same_partner:
                 self.date_due = max(invoices.mapped("invoice_date_due"))


### PR DESCRIPTION
Applied changes on due_date for take care about the partner groups on register payments.

On one hand, if the field due_date is empty the camp will take the latest due_date of the invoices that form the payment.

On the other hand, if we set a value on due_date field, all the payments generated will take this value.

On next gif you can see how it is working.
![1](https://user-images.githubusercontent.com/35952655/99548878-65e30f00-29b9-11eb-8275-6795ee7a8e0c.gif)

Please @carlosdauden @sergio-teruel, can you review this?