### PR TITLE
[12.0] [IMP] account_payment_promissory_note: Changes on due_date

### DIFF
--- a/account_payment_promissory_note/i18n/account_payment_promissory_note.pot
+++ b/account_payment_promissory_note/i18n/account_payment_promissory_note.pot
@@ -6,12 +6,21 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-12-04 14:22+0000\n"
+"PO-Revision-Date: 2020-12-04 14:22+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
+
+#. module: account_payment_promissory_note
+#: model_terms:ir.ui.view,arch_db:account_payment_promissory_note.view_account_payment_from_invoices
+msgid "<span class=\"text-muted\" attrs=\"{'invisible': [('promissory_note','=', False)]}\">\n"
+"                    Set date due to all payments or empty to select last date due of each partner invoices group\n"
+"                </span>"
+msgstr ""
 
 #. module: account_payment_promissory_note
 #: model:ir.model,name:account_payment_promissory_note.model_account_abstract_payment

--- a/account_payment_promissory_note/i18n/es.po
+++ b/account_payment_promissory_note/i18n/es.po
@@ -6,29 +6,40 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-10-14 08:53+0000\n"
-"PO-Revision-Date: 2020-10-14 10:55+0200\n"
+"POT-Creation-Date: 2020-12-04 14:22+0000\n"
+"PO-Revision-Date: 2020-12-04 15:23+0100\n"
+"Last-Translator: Carlos <carlos.roca@tecnativa.com>\n"
 "Language-Team: \n"
+"Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 2.0.6\n"
-"Last-Translator: Carlos <carlos.roca@tecnativa.com>\n"
-"Language: es\n"
+
+#. module: account_payment_promissory_note
+#: model_terms:ir.ui.view,arch_db:account_payment_promissory_note.view_account_payment_from_invoices
+msgid ""
+"<span class=\"text-muted\" attrs=\"{'invisible': [('promissory_note','=', "
+"False)]}\">\n"
+"                    Set date due to all payments or empty to select last "
+"date due of each partner invoices group\n"
+"                </span>"
+msgstr ""
+"<span class=\"text-muted\" attrs=\"{'invisible': [('promissory_note','=', "
+"False)]}\">\n"
+"                   Selecciona una fecha de vencimiento para todos los pagos "
+"o dejalo vacío para que se seleccione la última fecha de vencimiento para "
+"cada agrupación de facturas de un mismo proveedor.\n"
+"                </span>"
 
 #. module: account_payment_promissory_note
 #: model:ir.model,name:account_payment_promissory_note.model_account_abstract_payment
-msgid "Contains the logic shared between models which allows to register payments"
-msgstr "Contiene la lógica compartida entre los modelos que permiten el registro de pagos"
-
-#. module: account_payment_promissory_note
-#: model:ir.model.fields,field_description:account_payment_promissory_note.field_account_abstract_payment__promissory_note
-#: model:ir.model.fields,field_description:account_payment_promissory_note.field_account_payment__promissory_note
-#: model:ir.model.fields,field_description:account_payment_promissory_note.field_account_register_payments__promissory_note
-#: model_terms:ir.ui.view,arch_db:account_payment_promissory_note.view_account_payment_search
-msgid "Promissory Note"
-msgstr "Pagaré"
+msgid ""
+"Contains the logic shared between models which allows to register payments"
+msgstr ""
+"Contiene la lógica compartida entre los modelos que permiten el registro de "
+"pagos"
 
 #. module: account_payment_promissory_note
 #: model:ir.model.fields,field_description:account_payment_promissory_note.field_account_abstract_payment__date_due
@@ -41,6 +52,14 @@ msgstr "Fecha de Vencimiento"
 #: model:ir.model,name:account_payment_promissory_note.model_account_payment
 msgid "Payments"
 msgstr "Pagos"
+
+#. module: account_payment_promissory_note
+#: model:ir.model.fields,field_description:account_payment_promissory_note.field_account_abstract_payment__promissory_note
+#: model:ir.model.fields,field_description:account_payment_promissory_note.field_account_payment__promissory_note
+#: model:ir.model.fields,field_description:account_payment_promissory_note.field_account_register_payments__promissory_note
+#: model_terms:ir.ui.view,arch_db:account_payment_promissory_note.view_account_payment_search
+msgid "Promissory Note"
+msgstr "Pagaré"
 
 #. module: account_payment_promissory_note
 #: model:ir.model,name:account_payment_promissory_note.model_account_register_payments

--- a/account_payment_promissory_note/models/account_payment.py
+++ b/account_payment_promissory_note/models/account_payment.py
@@ -27,8 +27,11 @@ class AccountPayment(models.Model):
     def _onchange_promissory_note(self):
         super()._onchange_promissory_note()
         if not self.date_due and self.promissory_note:
-            invoices = False
-            if self._name == 'account.payment':
-                invoices = self.invoice_ids
-            if invoices:
-                self.date_due = max(invoices.mapped('date_due'))
+            invoices = self.invoice_ids
+            partner = invoices[0].partner_id
+            same_partner = True
+            for invoice in invoices:
+                if invoice.partner_id != partner:
+                    same_partner = False
+            if invoices and same_partner:
+                self.date_due = max(invoices.mapped("date_due"))

--- a/account_payment_promissory_note/views/account_payment_invoice_view.xml
+++ b/account_payment_promissory_note/views/account_payment_invoice_view.xml
@@ -7,6 +7,12 @@
             <xpath expr="//field[@name='payment_date']" position="after">
                 <field name="promissory_note"/>
                 <field name="date_due" attrs="{'invisible': [('promissory_note','=', False)]}"/>
+                <span
+                    class="text-muted"
+                    attrs="{'invisible': [('promissory_note','=', False)]}"
+                >
+                    Set date due to all payments or empty to select last date due of each partner invoices group
+                </span>
             </xpath>
         </field>
     </record>

--- a/account_payment_promissory_note/wizard/account_register_payments.py
+++ b/account_payment_promissory_note/wizard/account_register_payments.py
@@ -9,21 +9,30 @@ class AccountRegisterPayments(models.TransientModel):
     _inherit = 'account.register.payments'
 
     def get_payments_vals(self):
-        vals = super(AccountRegisterPayments, self).get_payments_vals()
+        vals = super().get_payments_vals()
         for val in vals:
-            val.update({
-                'promissory_note': self.promissory_note,
-                'date_due': self.date_due,
-            })
+            if not self.date_due:
+                invoices = self.env["account.invoice"].browse(val["invoice_ids"][0][2])
+                max_date = max(invoices.mapped("date_due"))
+                val.update(
+                    {"promissory_note": self.promissory_note, "date_due": max_date}
+                )
+            else:
+                val.update(
+                    {"promissory_note": self.promissory_note, "date_due": self.date_due}
+                )
         return vals
 
     @api.onchange('promissory_note')
     def _onchange_promissory_note(self):
         super()._onchange_promissory_note()
         if not self.date_due and self.promissory_note:
-            invoices = False
-            if self._name == 'account.register.payments':
-                active_ids = self._context.get('active_ids')
-                invoices = self.env['account.invoice'].browse(active_ids)
-            if invoices:
+            active_ids = self._context.get('active_ids')
+            invoices = self.env['account.invoice'].browse(active_ids)
+            partner = invoices[0].partner_id
+            same_partner = True
+            for invoice in invoices:
+                if invoice.partner_id != partner:
+                    same_partner = False
+            if invoices and self.group_invoices and same_partner:
                 self.date_due = max(invoices.mapped('date_due'))


### PR DESCRIPTION
cc @Tecnativa TT27088

Applied changes on due_date for take care about the partner groups on register payments.

On one hand, if the field due_date is empty the camp will take the latest due_date of the invoices that form the payment.

On the other hand, if we set a value on due_date field, all the payments generated will take this value.

On next gif you can see how it is working.
![1](https://user-images.githubusercontent.com/35952655/101176128-5d8c0480-3646-11eb-9e9c-e884a8d37e59.gif)

Please @sergio-teruel @carlosdauden review this
