### PR TITLE
[13.0][IMP] account_payment_term_extension: Add amount_untaxed to value option in payment term lines

### DIFF
--- a/account_payment_term_extension/demo/account_demo.xml
+++ b/account_payment_term_extension/demo/account_demo.xml
@@ -11,4 +11,15 @@
                       ]"
         />
     </record>
+    <record id="amount_untaxed_lines" model="account.payment.term">
+        <field name="name">10% + 40% + Balance</field>
+        <field name="sequential_lines" eval="True" />
+        <field
+            name="line_ids"
+            eval="[(5, 0), (0, 0, {'option': 'day_after_invoice_date', 'sequence': 10, 'value': 'amount_untaxed', 'value_amount_untaxed': 10}),
+                      (0,0, {'option': 'day_after_invoice_date', 'sequence': 20, 'value': 'amount_untaxed', 'value_amount_untaxed': 40}),
+                      (0,0, {'option': 'day_after_invoice_date', 'sequence': 30, 'value': 'balance', 'value_amount_untaxed': 0})
+                      ]"
+        />
+    </record>
 </odoo>

--- a/account_payment_term_extension/i18n/account_payment_term_extension.pot
+++ b/account_payment_term_extension/i18n/account_payment_term_extension.pot
@@ -6,12 +6,19 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-01-08 07:29+0000\n"
+"PO-Revision-Date: 2021-01-08 07:29+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
+
+#. module: account_payment_term_extension
+#: model:account.payment.term,name:account_payment_term_extension.amount_untaxed_lines
+msgid "10% + 40% + Balance"
+msgstr ""
 
 #. module: account_payment_term_extension
 #: model:account.payment.term,name:account_payment_term_extension.sixty_days_end_of_month
@@ -79,6 +86,11 @@ msgid "ID"
 msgstr ""
 
 #. module: account_payment_term_extension
+#: model:ir.model,name:account_payment_term_extension.model_account_move
+msgid "Journal Entries"
+msgstr ""
+
+#. module: account_payment_term_extension
 #: model:ir.model.fields,field_description:account_payment_term_extension.field_account_payment_term_holiday____last_update
 msgid "Last Modified on"
 msgstr ""
@@ -135,6 +147,17 @@ msgid "Payment days field format is not valid."
 msgstr ""
 
 #. module: account_payment_term_extension
+#: model:ir.model.fields.selection,name:account_payment_term_extension.selection__account_payment_term_line__value__amount_untaxed
+msgid "Percent (Untaxed amount)"
+msgstr ""
+
+#. module: account_payment_term_extension
+#: code:addons/account_payment_term_extension/models/account_payment_term.py:0
+#, python-format
+msgid "Percentages on the Payment Terms lines must be between 0 and 100."
+msgstr ""
+
+#. module: account_payment_term_extension
 #: model:ir.model.fields,field_description:account_payment_term_extension.field_account_payment_term_holiday__date_postponed
 msgid "Postponed date"
 msgstr ""
@@ -147,6 +170,11 @@ msgid ""
 msgstr ""
 
 #. module: account_payment_term_extension
+#: model:ir.model.fields,help:account_payment_term_extension.field_account_payment_term_line__value
+msgid "Select here the kind of valuation related to this payment terms line."
+msgstr ""
+
+#. module: account_payment_term_extension
 #: model:ir.model.fields,field_description:account_payment_term_extension.field_account_payment_term__sequential_lines
 msgid "Sequential lines"
 msgstr ""
@@ -156,6 +184,11 @@ msgstr ""
 msgid ""
 "Sets the amount so that it is a multiple of this value.\n"
 "To have amounts that end in 0.99, set rounding 1, surcharge -0.01"
+msgstr ""
+
+#. module: account_payment_term_extension
+#: model:ir.model.fields,field_description:account_payment_term_extension.field_account_payment_term_line__value
+msgid "Type"
 msgstr ""
 
 #. module: account_payment_term_extension

--- a/account_payment_term_extension/i18n/es.po
+++ b/account_payment_term_extension/i18n/es.po
@@ -6,16 +6,21 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 11.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-04-16 17:15+0000\n"
-"PO-Revision-Date: 2019-07-22 20:43+0000\n"
+"POT-Creation-Date: 2021-01-08 07:29+0000\n"
+"PO-Revision-Date: 2021-01-08 08:30+0100\n"
 "Last-Translator: Josep M <jmyepes@mac.com>\n"
 "Language-Team: \n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 3.7.1\n"
+"X-Generator: Poedit 2.3\n"
+
+#. module: account_payment_term_extension
+#: model:account.payment.term,name:account_payment_term_extension.amount_untaxed_lines
+msgid "10% + 40% + Balance"
+msgstr "10% + 40% + Balance"
 
 #. module: account_payment_term_extension
 #: model:account.payment.term,name:account_payment_term_extension.sixty_days_end_of_month
@@ -83,6 +88,11 @@ msgid "ID"
 msgstr "ID (identificación)"
 
 #. module: account_payment_term_extension
+#: model:ir.model,name:account_payment_term_extension.model_account_move
+msgid "Journal Entries"
+msgstr "Asientos contables"
+
+#. module: account_payment_term_extension
 #: model:ir.model.fields,field_description:account_payment_term_extension.field_account_payment_term_holiday____last_update
 msgid "Last Modified on"
 msgstr "Última modificación en"
@@ -139,6 +149,19 @@ msgid "Payment days field format is not valid."
 msgstr "El campo días de pago no tiene un formato válido."
 
 #. module: account_payment_term_extension
+#: model:ir.model.fields.selection,name:account_payment_term_extension.selection__account_payment_term_line__value__amount_untaxed
+msgid "Percent (Untaxed amount)"
+msgstr "Porcentaje (Base imponible)"
+
+#. module: account_payment_term_extension
+#: code:addons/account_payment_term_extension/models/account_payment_term.py:0
+#, python-format
+msgid "Percentages on the Payment Terms lines must be between 0 and 100."
+msgstr ""
+"Los porcentajes en las líneas de Condiciones de pago deben estar entre 0 y "
+"100."
+
+#. module: account_payment_term_extension
 #: model:ir.model.fields,field_description:account_payment_term_extension.field_account_payment_term_holiday__date_postponed
 msgid "Postponed date"
 msgstr "Fecha postpuesta"
@@ -151,6 +174,13 @@ msgid ""
 msgstr ""
 "Ponga aquí el día o los días en que el socio hace el pago. Separe cada día "
 "de pago posible con guiones (-), comas (,) o espacios ( )."
+
+#. module: account_payment_term_extension
+#: model:ir.model.fields,help:account_payment_term_extension.field_account_payment_term_line__value
+msgid "Select here the kind of valuation related to this payment terms line."
+msgstr ""
+"Seleccione aquí el tipo de valoración relacionada con esta línea de "
+"condiciones de pago."
 
 #. module: account_payment_term_extension
 #: model:ir.model.fields,field_description:account_payment_term_extension.field_account_payment_term__sequential_lines
@@ -168,6 +198,11 @@ msgstr ""
 "-0,01"
 
 #. module: account_payment_term_extension
+#: model:ir.model.fields,field_description:account_payment_term_extension.field_account_payment_term_line__value
+msgid "Type"
+msgstr "TIpo"
+
+#. module: account_payment_term_extension
 #: model_terms:ir.ui.view,arch_db:account_payment_term_extension.view_payment_term_form
 msgid ""
 "When a payment term coincides with a holiday, it is postponed to the chosen "
@@ -175,6 +210,9 @@ msgid ""
 msgstr ""
 "Cuando un plazo de pago coincide con un festivo, se postpone a la fecha "
 "elegida."
+
+#~ msgid "Amount untaxed (percent)"
+#~ msgstr "Base imponible (porcentaje)"
 
 #~ msgid "Due Date Computation"
 #~ msgstr "Cálculo de fecha de vencimiento"

--- a/account_payment_term_extension/models/__init__.py
+++ b/account_payment_term_extension/models/__init__.py
@@ -1,1 +1,2 @@
+from . import account_move
 from . import account_payment_term

--- a/account_payment_term_extension/models/account_move.py
+++ b/account_payment_term_extension/models/account_move.py
@@ -1,0 +1,14 @@
+# Copyright 2021 Tecnativa Víctor Martínez
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+
+from odoo import models
+
+
+class AccountMove(models.Model):
+    _inherit = "account.move"
+
+    def _recompute_payment_terms_lines(self):
+        super(
+            AccountMove, self.with_context(last_stock_move=self)
+        )._recompute_payment_terms_lines()

--- a/account_payment_term_extension/readme/CONTRIBUTORS.rst
+++ b/account_payment_term_extension/readme/CONTRIBUTORS.rst
@@ -7,6 +7,7 @@
 
   * Pedro M. Baeza
   * Vicent Cubells
+  * Víctor Martínez
 
 * `Domatix <https://domatix.com>`:
 

--- a/account_payment_term_extension/readme/DESCRIPTION.rst
+++ b/account_payment_term_extension/readme/DESCRIPTION.rst
@@ -1,5 +1,6 @@
 This module extends the functionality of payment terms to :
 
+* select "Percent (untaxed amount)" type in lines for using the base amount instead of the total (with taxes) one.
 * support rounding, months and weeks on payment term lines
 * allow to set more than one day of payment in payment terms
 * if a payment term date is a holiday, it is postponed to a selected date

--- a/account_payment_term_extension/tests/test_account_payment_term_multi_day.py
+++ b/account_payment_term_extension/tests/test_account_payment_term_multi_day.py
@@ -1,5 +1,7 @@
 import odoo.tests.common as common
 from odoo import fields
+from odoo.exceptions import ValidationError
+from odoo.tests.common import Form
 
 
 class TestAccountPaymentTermMultiDay(common.TransactionCase):
@@ -100,6 +102,74 @@ class TestAccountPaymentTermMultiDay(common.TransactionCase):
                 ],
             }
         )
+        self.amount_untaxed_lines = self.payment_term_model.create(
+            {
+                "name": "10 percent + 40 percent + Balance",
+                "active": True,
+                "sequential_lines": True,
+                "line_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "value": "amount_untaxed",
+                            "value_amount_untaxed": 10.0,
+                            "option": "day_after_invoice_date",
+                        },
+                    ),
+                    (
+                        0,
+                        0,
+                        {
+                            "value": "amount_untaxed",
+                            "value_amount_untaxed": 40.0,
+                            "option": "day_after_invoice_date",
+                        },
+                    ),
+                    (0, 0, {"value": "balance", "option": "day_after_invoice_date"}),
+                ],
+            }
+        )
+
+    def test_amount_untaxed_payment_term_error(self):
+        payment_term_form = Form(self.payment_term_model)
+        payment_term_form.name = "10 percent + 40 percent + Balance"
+        payment_term_form.sequential_lines = True
+        with payment_term_form.line_ids.new() as line_form:
+            line_form.value = "amount_untaxed"
+            line_form.value_amount = 110
+            line_form.option = "day_after_invoice_date"
+        with self.assertRaises(ValidationError):
+            payment_term_form.save()
+
+    def test_account_invoice_with_custom_payment_term(self):
+        invoice = self.invoice_model.create(
+            {
+                "journal_id": self.journal.id,
+                "partner_id": self.partner.id,
+                "invoice_payment_term_id": self.amount_untaxed_lines.id,
+                "invoice_date": "%s-01-01" % fields.datetime.now().year,
+                "type": "in_invoice",
+                "name": "10 percent + 40 percent + Balance",
+                "invoice_line_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": self.product.id,
+                            "name": "Test",
+                            "quantity": 10.0,
+                            "price_unit": 100.00,
+                            "account_id": self.prod_account.id,
+                        },
+                    )
+                ],
+            }
+        )
+        invoice.post()
+        self.assertEqual(invoice.line_ids[1].credit, 100.0)
+        self.assertEqual(invoice.line_ids[2].credit, 400.0)
+        self.assertEqual(invoice.line_ids[3].credit, 500.0)
 
     def test_invoice_normal_payment_term(self):
         invoice = self.invoice_model.create(

--- a/account_payment_term_extension/views/account_payment_term.xml
+++ b/account_payment_term_extension/views/account_payment_term.xml
@@ -38,6 +38,12 @@
         <field name="model">account.payment.term.line</field>
         <field name="inherit_id" ref="account.view_payment_term_line_form" />
         <field name="arch" type="xml">
+            <field name="value_amount" position="after">
+                <field
+                    name="value_amount_untaxed"
+                    attrs="{'invisible':[('value','!=', 'amount_untaxed')]}"
+                />
+            </field>
             <xpath expr="//div[hasclass('o_row')]" position="after">
                 <br />
                 <div attrs="{'invisible':[('value','=', 'balance')]}" class="o_row">


### PR DESCRIPTION
Add `amount_untaxed` to value option in payment term lines (%) related to invoice.

Please, @joao-p-marques  review it.
@Tecnativa TT27625