### PR TITLE
[12.0][FIX] account_check_printing_report_base: Tens in word cents are showed as units (Only ES)

### DIFF
--- a/account_check_printing_report_base/report/lang.py
+++ b/account_check_printing_report_base/report/lang.py
@@ -2,6 +2,7 @@
 from num2words import num2words
 from num2words import CONVERTER_CLASSES, CONVERTES_TYPES
 from num2words.lang_ES import Num2Word_ES
+from num2words.base import Num2Word_Base
 
 num2words_by_lang = {
     'es': 'Num2WordESCustom'
@@ -9,15 +10,15 @@ num2words_by_lang = {
 
 
 class Num2WordESCustom(Num2Word_ES):
-    # Replace centavo to céntimo. Original method copy
+    CURRENCY_FORMS = Num2Word_ES.CURRENCY_FORMS.copy()
+    CURRENCY_FORMS.update({
+        'EUR': (('euro', 'euros'), ('céntimo', 'céntimos')),
+    })
+
+    # TODO: PR to remove overwrite in num2words code and use CURRENCY_FORMS
     def to_currency(self, val, longval=True, old=False):
-        hightxt, lowtxt = "euro/s", u"céntimo/s"
-        if old:
-            hightxt, lowtxt = "peso/s", "peseta/s"
-        result = self.to_splitnum(val, hightxt=hightxt, lowtxt=lowtxt,
-                                  divisor=1, jointxt="y", longval=longval)
-        # Handle exception, in spanish is "un euro" and not "uno euro"
-        return result.replace("uno", "un")
+        return Num2Word_Base.to_currency(self, val, currency='EUR', cents=True,
+                                         seperator=' con', adjective=False)
 
 
 def num2words_custom(number, ordinal=False, lang='en', to='cardinal', **kwargs):


### PR DESCRIPTION
Improve code using evolutioned base method instead of custom method.

Avoid overwrite precision…(4.90 returns four dot nine instead of four dot ninety)
https://github.com/savoirfairelinux/num2words/commit/1c699d1bb411f42b37f619fb6560e6f03d67c463#diff-28b986a636d0cd36a886fb49a7dcde88885ec58befc6dbb7901b3ffe54a35a20R112

Before this PR:
4.90 returns "cuatro euros con nueve céntimos"

Before this PR:
4.90 returns "cuatro euros con noventa céntimos"

@Tecnativa TT27765