### PR TITLE
[13.0][FIX]account_payment_term_extension option='after_invoice_month'

### DIFF
--- a/account_payment_term_extension/models/account_payment_term.py
+++ b/account_payment_term_extension/models/account_payment_term.py
@@ -5,6 +5,7 @@
 # Copyright 2018 Simone Rubino - Agile Business Group
 # Copyright 2021 Tecnativa - Víctor Martínez
 # Copyright 2021 Tecnativa - Pedro M. Baeza
+# Copyright 2021 Noviat
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 import calendar
@@ -245,7 +246,9 @@ class AccountPaymentTerm(models.Model):
                 # Getting 1st of next month
                 next_first_date = next_date + relativedelta(day=1, months=1)
                 # Then add days
-                next_date = next_first_date + relativedelta(days=line.days - 1)
+                next_date = next_first_date + relativedelta(
+                    days=line.days - 1, weeks=line.weeks, months=line.months
+                )
             next_date = self.apply_payment_days(line, next_date)
             next_date = self.apply_holidays(next_date)
             if not float_is_zero(amt, precision_digits=precision_digits):

--- a/account_payment_term_extension/tests/__init__.py
+++ b/account_payment_term_extension/tests/__init__.py
@@ -1,2 +1,3 @@
+from . import test_payment_term_after_invoice_month
 from . import test_account_payment_term_multi_day
 from . import test_payment_term

--- a/account_payment_term_extension/tests/test_payment_term_after_invoice_month.py
+++ b/account_payment_term_extension/tests/test_payment_term_after_invoice_month.py
@@ -1,0 +1,85 @@
+# Copyright 2021 Noviat
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.tests.common import TransactionCase
+
+
+class TestAccountPaymentTermAfterInvoiceMonth(TransactionCase):
+    def setUp(self):
+        super().setUp()
+        self.payment_term_model = self.env["account.payment.term"]
+
+    def test_after_invoice_month_days_compute(self):
+        pt = self.payment_term_model.create(
+            {
+                "name": "5 days after end of the invoice month",
+                "active": True,
+                "line_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "value": "balance",
+                            "days": 5,
+                            "option": "after_invoice_month",
+                        },
+                    )
+                ],
+            }
+        )
+        res = pt.compute(10, date_ref="2021-01-15")
+        self.assertEquals(
+            res[0][0],
+            "2021-02-05",
+            "Error in the compute of 'after_invoice_month' with days",
+        )
+
+    def test_after_invoice_month_weeks_compute(self):
+        pt = self.payment_term_model.create(
+            {
+                "name": "2 weeks day after end of the invoice month",
+                "active": True,
+                "line_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "value": "balance",
+                            "weeks": 2,
+                            "option": "after_invoice_month",
+                        },
+                    )
+                ],
+            }
+        )
+        res = pt.compute(10, date_ref="2021-01-15")
+        self.assertEquals(
+            res[0][0],
+            "2021-02-14",
+            "Error in the compute of 'after_invoice_month' with weeks",
+        )
+
+    def test_after_invoice_month_months_compute(self):
+        pt = self.payment_term_model.create(
+            {
+                "name": "2 months day after end of the invoice month",
+                "active": True,
+                "line_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "value": "balance",
+                            "months": 2,
+                            "option": "after_invoice_month",
+                        },
+                    )
+                ],
+            }
+        )
+        res = pt.compute(10, date_ref="2021-01-15")
+        self.assertEquals(
+            res[0][0],
+            "2021-03-31",
+            "Error in the compute of 'after_invoice_month' with months",
+        )


### PR DESCRIPTION
https://github.com/OCA/account-payment/pull/369 has fixed the after_invoice_month option for the 'days' use case but the weeks and months options are not supported.
This PR fixes this and also adds 3 unit tests to cover those use cases.
