### PR TITLE
[13.0][IMP] account_payment_return: Fill credit move line with partner

### DIFF
--- a/account_payment_return/models/payment_return.py
+++ b/account_payment_return/models/payment_return.py
@@ -225,6 +225,7 @@ class PaymentReturn(models.Model):
         move = self.env["account.move"].create(self._prepare_return_move_vals())
         total_amount = 0.0
         all_move_lines = self.env["account.move.line"]
+        debit_move_partner = self.env["res.partner"]
         for return_line in self.line_ids:
             move_line2_vals = return_line._prepare_return_move_line_vals(move)
             move_line2 = move_line_model.with_context(check_move_validity=False).create(
@@ -251,7 +252,10 @@ class PaymentReturn(models.Model):
                 )
             extra_lines_vals = return_line._prepare_extra_move_lines(move)
             move_line_model.create(extra_lines_vals)
+            debit_move_partner = move_line2.partner_id
         move_line_vals = self._prepare_move_line(move, total_amount)
+        if debit_move_partner:
+            move_line_vals["partner_id"] = debit_move_partner.id
         # credit_move_line: credit on transfer or bank account
         credit_move_line = move_line_model.create(move_line_vals)
         # Reconcile (if option enabled)


### PR DESCRIPTION
Fill the move line for credit with the same partner as the debit move line

Reason for the change is to be able to concile correctly with the Spanish bank rule 43.

I don't believe this change should affect anything else that might want that field to be treated differently, however since it is to my knowledge a Spanish thing (I don't know if it's relevant in other countries), it might be better to move this change to the `l10n-spain` repo
