### PR TITLE
[10.0][FIX]account_check_report

### DIFF
--- a/account_check_report/__init__.py
+++ b/account_check_report/__init__.py
@@ -1,1 +1,2 @@
 from . import report
+from . import models

--- a/account_check_report/__manifest__.py
+++ b/account_check_report/__manifest__.py
@@ -11,7 +11,7 @@
               "Odoo Community Association (OCA)",
     'category': 'Generic Modules/Accounting',
     'website': "https://github.com/OCA/account-payment",
-    'depends': [],
+    'depends': ["account"],
     'data': [
         'report/account_check_report.xml',
     ],

--- a/account_check_report/models/__init__.py
+++ b/account_check_report/models/__init__.py
@@ -1,0 +1,1 @@
+from . import account_payment

--- a/account_check_report/models/account_payment.py
+++ b/account_check_report/models/account_payment.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+# 2016-2021 ForgeFlow S.L.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from odoo import api, models
+from odoo.osv import expression
+
+
+class AccountPayment(models.Model):
+    _inherit = "account.payment"
+
+    def get_direct_refunds(self):
+        rec_lines = self.move_line_ids.filtered(
+            lambda x: x.account_id.reconcile
+            and x.account_id == self.destination_account_id
+            and x.partner_id == self.partner_id
+        )
+        # include direct refunds
+        if self.partner_type == "customer":
+            invoice_ids = rec_lines.mapped(
+                "matched_debit_ids.debit_move_id.matched_credit_ids."
+                "credit_move_id.invoice_id"
+            ).filtered(lambda i: i.date_invoice <= self.payment_date)
+        elif self.partner_type == "supplier":
+            invoice_ids = rec_lines.mapped(
+                "matched_credit_ids.credit_move_id.matched_debit_ids."
+                "debit_move_id.invoice_id"
+            ).filtered(lambda i: i.date_invoice <= self.payment_date)
+        # include other invoices where the payment was applied
+        invoice_ids += rec_lines.mapped(
+            "matched_credit_ids.credit_move_id.invoice_id"
+        ) + rec_lines.mapped("matched_debit_ids.debit_move_id.invoice_id")
+        if not invoice_ids:
+            return False
+        return [("id", "in", invoice_ids.ids)]
+
+    @api.multi
+    def button_invoices(self):
+        """
+        Include direct refunds, those are not linked to the payments
+        directly
+        """
+        res = super(AccountPayment, self).button_invoices()
+        if not res.get("domain", False):
+            return res
+        result_domain = res.get("domain", False)
+        direct_refunds_domain = self.get_direct_refunds()
+        if direct_refunds_domain:
+            res["domain"] = expression.OR(
+                [result_domain, direct_refunds_domain]
+            )
+        return res

--- a/account_check_report/report/account_check_report.xml
+++ b/account_check_report/report/account_check_report.xml
@@ -32,10 +32,10 @@
                                     <t name="paid_lines_loop" t-foreach="paid_lines(o)" t-as="line">
                                         <tr style="text-align:left;border-top: 0px;">
                                             <td style="padding-top:2mm;">
-                                                <span t-esc="_format_date_to_partner_lang(line.date_maturity, o.partner_id.id)"/>
+                                                <span t-esc="_format_date_to_partner_lang(line[0].date_maturity, o.partner_id.id)"/>
                                             </td>
                                             <td style="max-width: 55mm;"
-                                                t-esc="line.display_name"/>
+                                                t-esc="line[0].display_name"/>
                                             <td>
                                                 <span t-esc="total_amount(o, line)"
                                                       t-options="{'widget': 'monetary', 'display_currency': o.currency_id}"/>

--- a/account_check_report/report/report_helper.py
+++ b/account_check_report/report/report_helper.py
@@ -21,11 +21,38 @@ class ReportCheckPrint(models.AbstractModel):
 
     def _get_paid_lines(self, payment):
         rec_lines = payment.move_line_ids.filtered(
-            lambda x: x.account_id.reconcile and x.account_id ==
-            payment.destination_account_id
-            and x.partner_id == payment.partner_id)
-        amls = rec_lines.mapped('matched_credit_ids.credit_move_id') + \
-            rec_lines.mapped('matched_debit_ids.debit_move_id')
+            lambda x: x.account_id.reconcile
+            and x.account_id == payment.destination_account_id
+            and x.partner_id == payment.partner_id
+        )
+        amls = rec_lines.mapped(
+            "matched_credit_ids.credit_move_id"
+        ) + rec_lines.mapped("matched_debit_ids.debit_move_id")
+        # Include direct refunds:
+        if payment.partner_type == "customer":
+            amls += rec_lines.mapped(
+                "matched_debit_ids.debit_move_id.matched_credit_ids."
+                "credit_move_id"
+            ).filtered(
+                lambda l: l.invoice_id
+                not in rec_lines.mapped(
+                    "matched_debit_ids.debit_move_id.invoice_id"
+                )
+                and l.invoice_id
+                and l.invoice_id.date_invoice <= payment.payment_date
+            )
+        elif payment.partner_type == "supplier":
+            amls += rec_lines.mapped(
+                "matched_credit_ids.credit_move_id.matched_debit_ids."
+                "debit_move_id"
+            ).filtered(
+                lambda l: l.invoice_id
+                not in rec_lines.mapped(
+                    "matched_credit_ids.credit_move_id.invoice_id"
+                )
+                and l.invoice_id
+                and l.invoice_id.date_invoice <= payment.payment_date
+            )
         amls -= rec_lines
         # Here we need to handle a nasty corner case.
         # Sometimes we match a payment with invoices and refunds. Internally
@@ -42,10 +69,29 @@ class ReportCheckPrint(models.AbstractModel):
             and x.account_id == payment.destination_account_id
             and x.partner_id == payment.partner_id)
         amls |= invoice_amls
-        return amls
+        res = []
+        invoices_checked = []
+        # Another nasty corner case:
+        # avoid printing more than one line for invoice where the
+        # payable/receivable line is split. That happens when using
+        # payment terms with several lines
+        # I group the lines by invoice below
+        for aml in amls:
+            invoice = aml.invoice_id
+            if invoice in invoices_checked:
+                # prevent duplicated lines
+                continue
+            if invoice:
+                invoices_checked.append(invoice)
+                amls_inv = amls.filtered(lambda l: l.invoice_id == invoice)
+                res.append([l for l in amls_inv])
+            else:
+                res.append([aml])
+        return res
 
-    def _get_residual_amount(self, payment, line):
-        amt = line.amount_residual
+    def _get_residual_amount(self, payment, lines):
+        amt = abs(lines[0].invoice_id.amount_total) - \
+            abs(self._get_paid_amount(payment, lines))
         if amt < 0.0:
             amt *= -1
         amt = payment.company_id.currency_id.with_context(
@@ -53,38 +99,106 @@ class ReportCheckPrint(models.AbstractModel):
             amt, payment.currency_id)
         return amt
 
-    def _get_paid_amount(self, payment, line):
-        amount = 0.0
-        total_amount_to_show = 0.0
-        # We pay out
-        if line.matched_credit_ids:
-            amount = -1 * sum([p.amount for p in line.matched_credit_ids])
-        # We receive payment
-        elif line.matched_debit_ids:
-            amount = sum([p.amount for p in line.matched_debit_ids])
+    def _get_paid_amount_this_payment(self, payment, lines):
+        "Get the paid amount for the payment at payment date"
+        agg_amt = 0
+        for line in lines:
+            amount = 0.0
+            total_paid_at_payment_date = 0.0
+            payment_invoices = payment.mapped('invoice_ids')
+            # Considering the dates of the partial reconcile
+            if line.matched_credit_ids:
+                amount = -1 * sum(
+                    [
+                        p.amount
+                        for p in line.matched_credit_ids.filtered(
+                            lambda l: l.credit_move_id.date
+                            <= payment.payment_date
+                            and (l.credit_move_id.payment_id == payment or not
+                                    l.credit_move_id.payment_id)
+                        )
+                    ]
+                )
+            # We receive payment
+            elif line.matched_debit_ids:
+                amount = sum(
+                    [
+                        p.amount
+                        for p in line.matched_debit_ids.filtered(
+                            lambda l: l.debit_move_id.date
+                            <= payment.payment_date
+                            and (l.debit_move_id.payment_id == payment or not
+                                    l.debit_move_id.payment_id)
+                        )
+                    ]
+                )
 
-        # In case of customer payment, we reverse the amounts
-        if payment.partner_type == 'customer':
-            amount *= -1
+            # In case of customer payment, we reverse the amounts
+            if payment.partner_type == "customer":
+                amount *= -1
+            amount_to_show = payment.company_id.currency_id.with_context(
+                date=payment.payment_date
+            ).compute(amount, payment.currency_id)
+            if not float_is_zero(
+                amount_to_show, precision_rounding=payment.currency_id.rounding
+            ):
+                total_paid_at_payment_date = amount_to_show
+            agg_amt += total_paid_at_payment_date
+        return agg_amt
 
-        amount_to_show = \
-            payment.company_id.currency_id.with_context(
+    def _get_paid_amount(self, payment, lines):
+        "Get the total paid amount for all payments at the payment date"
+        agg_amt = 0.0
+        for line in lines:
+            amount = 0.0
+            total_amount_to_show = 0.0
+            # Considering the dates of the partial reconcile
+            if line.matched_credit_ids:
+                amount = -1 * sum(
+                    [
+                        p.amount
+                        for p in line.matched_credit_ids.filtered(
+                            lambda l: l.credit_move_id.date
+                            <= payment.payment_date
+                        )
+                    ]
+                )
+            # We receive payment
+            elif line.matched_debit_ids:
+                amount = sum(
+                    [
+                        p.amount
+                        for p in line.matched_debit_ids.filtered(
+                            lambda l: l.debit_move_id.date
+                            <= payment.payment_date
+                        )
+                    ]
+                )
+
+            # In case of customer payment, we reverse the amounts
+            if payment.partner_type == "customer":
+                amount *= -1
+            amount_to_show = payment.company_id.currency_id.with_context(
+                date=payment.payment_date
+            ).compute(amount, payment.currency_id)
+            if not float_is_zero(
+                amount_to_show, precision_rounding=payment.currency_id.rounding
+            ):
+                total_amount_to_show = amount_to_show
+            agg_amt += total_amount_to_show
+        return agg_amt
+
+    def _get_total_amount(self, payment, lines):
+        agg_amt = 0
+        for line in lines:
+            amt = line.balance
+            if amt < 0.0 or line.invoice_id.type in ('in_refund', 'out_refund'):
+                amt *= -1
+            amt = payment.company_id.currency_id.with_context(
                 date=payment.payment_date).compute(
-                amount, payment.currency_id)
-        if not float_is_zero(
-                amount_to_show,
-                precision_rounding=payment.currency_id.rounding):
-            total_amount_to_show = amount_to_show
-        return total_amount_to_show
-
-    def _get_total_amount(self, payment, line):
-        amt = line.balance
-        if amt < 0.0:
-            amt *= -1
-        amt = payment.company_id.currency_id.with_context(
-            date=payment.payment_date).compute(
-            amt, payment.currency_id)
-        return amt
+                amt, payment.currency_id)
+            agg_amt += amt
+        return agg_amt
 
     @api.multi
     def render_html(self, docids, data=None):
@@ -97,7 +211,7 @@ class ReportCheckPrint(models.AbstractModel):
             'total_amount': self._get_total_amount,
             'paid_lines': self._get_paid_lines,
             'residual_amount': self._get_residual_amount,
-            'paid_amount': self._get_paid_amount,
+            'paid_amount': self._get_paid_amount_this_payment,
             '_format_date_to_partner_lang': self._format_date_to_partner_lang,
         }
         return self.env['report'].render(

--- a/account_check_report/tests/__init__.py
+++ b/account_check_report/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_account_check_report

--- a/account_check_report/tests/test_account_check_report.py
+++ b/account_check_report/tests/test_account_check_report.py
@@ -1,0 +1,169 @@
+# -*- coding: utf-8 -*-
+# 2016-2021 ForgeFlow S.L.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo.tests.common import TransactionCase
+from odoo.exceptions import UserError
+import time
+
+
+class TestAccountCheckReport(TransactionCase):
+    def setUp(self):
+        super(TestAccountCheckReport, self).setUp()
+        self.account_invoice_model = self.env["account.invoice"]
+        self.journal_model = self.env["account.journal"]
+        self.register_payments_model = self.env["account.register.payments"]
+        self.payment_method_model = self.env["account.payment.method"]
+        self.account_invoice_line_model = self.env["account.invoice.line"]
+        self.account_account_model = self.env["account.account"]
+        self.payment_model = self.env["account.payment"]
+
+        self.partner1 = self.env.ref("base.res_partner_1")
+        self.company = self.env.ref("base.main_company")
+        self.currency_usd_id = self.env.ref("base.USD").id
+        self.currency_euro_id = self.env.ref("base.EUR").id
+        self.acc_payable = self.env.ref("account.data_account_type_payable")
+        self.acc_expense = self.env.ref("account.data_account_type_expenses")
+        self.product = self.env.ref("product.product_product_4")
+        self.payment_method_check = self.payment_method_model.search(
+            [("code", "=", "check_printing")], limit=1,
+        )
+        if not self.payment_method_check:
+            self.payment_method_check = self.payment_method_model.create(
+                {
+                    "name": "Check",
+                    "code": "check_printing",
+                    "payment_type": "outbound",
+                    "check": True,
+                }
+            )
+        self.purchase_journal = self.journal_model.create(
+            {
+                "name": "Purchase Journal - Test",
+                "type": "purchase",
+                "code": "Test",
+            }
+        )
+        self.bank_journal = self.journal_model.create(
+            {
+                "name": "Cash Journal - Test",
+                "type": "bank",
+                "code": "bank",
+                "check_manual_sequencing": True,
+                "outbound_payment_method_ids": [
+                    (4, self.payment_method_check.id, None)
+                ],
+            }
+        )
+
+    def _create_account(self, name, code, user_type, reconcile):
+        account = self.account_account_model.create(
+            {
+                "name": name,
+                "code": code,
+                "user_type_id": user_type.id,
+                "company_id": self.company.id,
+                "reconcile": reconcile,
+            }
+        )
+        return account
+
+    def _create_vendor_bill(self, account):
+        vendor_bill = self.account_invoice_model.create(
+            {
+                "type": "in_invoice",
+                "partner_id": self.partner1.id,
+                "account_id": account.id,
+                "currency_id": self.company.currency_id.id,
+                "journal_id": self.purchase_journal.id,
+                "company_id": self.company.id,
+            }
+        )
+        return vendor_bill
+
+    def _create_invoice_line(self, account, invoice):
+        invoice_line = self.account_invoice_line_model.create(
+            {
+                "name": "Test invoice line",
+                "account_id": account.id,
+                "quantity": 1.000,
+                "price_unit": 2.99,
+                "invoice_id": invoice.id,
+                "product_id": self.product.id,
+            }
+        )
+        return invoice_line
+
+    def test_01_check_printing(self):
+        """ Test if the report is printed succesfully"""
+        acc_payable = self._create_account(
+            "account payable test", "ACPRB1", self.acc_payable, True
+        )
+        vendor_bill = self._create_vendor_bill(acc_payable)
+        acc_expense = self._create_account(
+            "account expense test", "ACPRB2", self.acc_expense, False
+        )
+        self._create_invoice_line(acc_expense, vendor_bill)
+        vendor_bill.action_invoice_open()
+        ctx = {
+            "active_model": "account.invoice",
+            "active_ids": [vendor_bill.id],
+        }
+        register_payments = self.register_payments_model.with_context(
+            ctx
+        ).create(
+            {
+                "payment_date": time.strftime("%Y") + "-07-15",
+                "journal_id": self.bank_journal.id,
+                "payment_method_id": self.payment_method_check.id,
+            }
+        )
+        register_payments.create_payment()
+        payment = self.payment_model.search([], order="id desc", limit=1)
+        e = False
+        try:
+            self.env[
+                "report.account_check_report.check_report"
+            ].render_html(payment.id,)
+        except UserError as e:
+            pass
+        self.assertEquals(e, False)
+
+    def test_02_get_invoices(self):
+        """ Test if the lines shown are good"""
+        acc_payable = self._create_account(
+            "account payable test", "ACPRB1", self.acc_payable, True
+        )
+        vendor_bill = self._create_vendor_bill(acc_payable)
+        acc_expense = self._create_account(
+            "account expense test", "ACPRB2", self.acc_expense, False
+        )
+        self._create_invoice_line(acc_expense, vendor_bill)
+        vendor_bill.action_invoice_open()
+        ctx = {
+            "active_model": "account.invoice",
+            "active_ids": [vendor_bill.id],
+        }
+        register_payments = self.register_payments_model.with_context(
+            ctx
+        ).create(
+            {
+                "payment_date": time.strftime("%Y") + "-07-15",
+                "journal_id": self.bank_journal.id,
+                "payment_method_id": self.payment_method_check.id,
+            }
+        )
+        register_payments.create_payment()
+        payment = self.payment_model.search([], order="id desc", limit=1)
+        amls = self.env[
+            "report.account_check_report.check_report"
+        ]._get_paid_lines(payment)
+        self.assertTrue(
+            vendor_bill.move_id.line_ids.filtered(
+                lambda l: l.account_id == acc_payable
+            )
+            in amls[0]
+        )
+        #  Test button invoices
+        domain_inv = payment.button_invoices()
+        self.assertTrue(vendor_bill.id in domain_inv['domain'][1][2])


### PR DESCRIPTION
If several payments are involved in the same invoice the report should show only the amount in the payment we are printing.

For example, one vendor bills for 10$ each and two payments for 5$ and 7$. The first payment is fully reconciled, the second payment is partially reconciled, 5$ to the bill and 2$ as residual amount. If we print the check report for that payment:

Previous this change:
![image](https://user-images.githubusercontent.com/19620251/110631240-9805c000-81a6-11eb-809e-74b46709d001.png)

After this change:
![image](https://user-images.githubusercontent.com/19620251/110631244-9a681a00-81a6-11eb-9bf4-a617fa936df2.png)

As you can see the payment column is confusing because it shows the total paid, including other payments, that is a little bit confusing and IMHO this approach makes more sense.

Besides that, in case when the invoice has complex payment terms, there are several payables and receivable lines by invoice. The last commit prevents to show several lines by invoices in the report. Currently it may appear several lines with the same invoice.