### PR TITLE
[14.0][FIX] account_payment_return: Fix automatic payment post

### DIFF
--- a/account_payment_return/tests/test_payment_return.py
+++ b/account_payment_return/tests/test_payment_return.py
@@ -87,7 +87,6 @@ class TestPaymentReturn(SavepointCase):
             )
         )
         cls.payment = payment_register.save()._create_payments()
-        cls.payment.action_post()
         cls.payment_move = cls.payment.move_id
         cls.payment_line = cls.payment_move.line_ids.filtered(
             lambda x: x.account_id.internal_type == "receivable"


### PR DESCRIPTION

A new check has been introduced in
https://github.com/odoo/odoo/commit/80c28189ae6b10ad17c4de2a781233a8ffe663a6

So, in test, when creating payment with payment register wizard, as
payments are automatically posted, duplicate posting is now forbidden.

https://github.com/odoo/odoo/blob/14.0/addons/account/wizard/account_payment_register.py#L512



The 14.0 branch is failing now. See https://travis-ci.com/github/OCA/account-payment/jobs/510343617

@joao-p-marques @pedrobaeza @sbejaoui 