### PR TITLE
[IMP] account_payment_return: Add general type journals to be selected in payment return

### DIFF
--- a/account_payment_return/views/payment_return_view.xml
+++ b/account_payment_return/views/payment_return_view.xml
@@ -51,7 +51,7 @@
                         <field name="name" />
                         <field
                             name="journal_id"
-                            domain="[('type', 'in', ['bank', 'cash'])]"
+                            domain="[('type', 'in', ['bank', 'cash', 'general'])]"
                         />
                         <field name="date" />
                         <field name="company_id" groups="base.group_multi_company" />


### PR DESCRIPTION
This patch allows the use of general type journals for the creation of the payment return voucher.

- https://github.com/OCA/account-payment/issues/220
- https://github.com/OCA/account-payment/issues/283

Regardless of this, we should make the appropriate modifications in the modules dependent of `account_payment_order` so that they adapt to the new flow and use the fields `payment_debit_account_id` `payment_credit_account_id` and `suspense_account_id`.


@Tecnativa TT29784