### PR TITLE
[12.0][FIX] account_payment_term_partner_holiday: Prevent error in tests when sale addon installed

### DIFF
--- a/account_payment_term_partner_holiday/tests/test_partner_holiday.py
+++ b/account_payment_term_partner_holiday/tests/test_partner_holiday.py
@@ -6,6 +6,8 @@ from odoo.tests.common import Form
 from odoo import fields
 
 
+@common.at_install(False)
+@common.post_install(True)
 class TestPartnerHoliday(common.TransactionCase):
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
Prevent error in tests when sale addon installed.

Steps to reproduce:
- Install `account_payment_term_partner_holiday`
- Install `sale`
- Run `account_payment_term_partner_holiday` tests

Please @joao-p-marques and @pedrobaeza can you review it?

@Tecnativa TT30526