### PR TITLE
[13.0][FIX] account_check_printing_report_base: Pin num2words version and fix typo in function call

### DIFF
--- a/account_check_printing_report_base/report/lang.py
+++ b/account_check_printing_report_base/report/lang.py
@@ -1,4 +1,3 @@
-# pylint: disable=missing-import-error
 from num2words import CONVERTER_CLASSES, CONVERTES_TYPES, num2words
 from num2words.base import Num2Word_Base
 from num2words.lang_ES import Num2Word_ES
@@ -12,9 +11,15 @@ class Num2WordESCustom(Num2Word_ES):
 
     # TODO: PR to remove overwrite in num2words code and use CURRENCY_FORMS
     def to_currency(self, val, longval=True, old=False):
-        return Num2Word_Base.to_currency(
-            self, val, currency="EUR", cents=True, separator=" con", adjective=False
-        )
+        try:
+            # On older versions we need to use "seperator" instead of "separator"
+            return Num2Word_Base.to_currency(
+                self, val, currency="EUR", cents=True, seperator=" con", adjective=False
+            )
+        except TypeError:
+            return Num2Word_Base.to_currency(
+                self, val, currency="EUR", cents=True, separator=" con", adjective=False
+            )
 
 
 def num2words_custom(number, ordinal=False, lang="en", to="cardinal", **kwargs):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 # generated from manifests external_dependencies
-num2words==0.5.10
+num2words


### PR DESCRIPTION
The current version used and installed by Odoo is 0.5.6: https://github.com/odoo/odoo/blob/13.0/requirements.txt#L21
It has a typo in the function call to `to_currency` where "separator" is spelled "seperator".
As that is the version that Odoo uses, we should adapt to it, and also pin to ensure we are installing the correct one.

The typo is fixed in https://github.com/savoirfairelinux/num2words/commit/2eee037648eb2245d9714f694e4868b80082a216 for version 0.5.10, so we should revert this if we ever upgrade to that version

@Tecnativa
TT30932

ping @pedrobaeza @sergio-teruel @CarlosRoca13 