### PR TITLE
[13.0][FIX] account_payment_term_partner_holiday: Improve is_date_in_holiday() to filtered correctly when day_to is less than date to compare

### DIFF
--- a/account_payment_term_partner_holiday/README.rst
+++ b/account_payment_term_partner_holiday/README.rst
@@ -44,6 +44,11 @@ To use this module, you need to:
    Invoices' and create or edit some record.
 #. If the computed due date is inside a holidays period, it's moved to the first available date.
 
+Known issues / Roadmap
+======================
+
+* Due dates for invoices are not updated when new holidays are created after.
+
 Bug Tracker
 ===========
 

--- a/account_payment_term_partner_holiday/__manifest__.py
+++ b/account_payment_term_partner_holiday/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     "name": "Account Payment Term Partner Holiday",
-    "version": "13.0.1.0.0",
+    "version": "13.0.1.1.0",
     "website": "https://github.com/OCA/account-payment",
     "author": "Tecnativa, Odoo Community Association (OCA)",
     "license": "AGPL-3",

--- a/account_payment_term_partner_holiday/migrations/13.0.1.1.0/post-migration.py
+++ b/account_payment_term_partner_holiday/migrations/13.0.1.1.0/post-migration.py
@@ -1,0 +1,24 @@
+# Copyright 2021 Tecnativa - Víctor Martínez
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openupgradelib import openupgrade
+from psycopg2 import sql
+
+
+def convert_field_to_two_characters(env, field_name):
+    openupgrade.logged_query(
+        env.cr,
+        sql.SQL(
+            """
+        UPDATE res_partner_holiday
+        SET {field_name} = CONCAT('0', {field_name})
+        WHERE length({field_name}) = 1
+        """
+        ).format(field_name=field_name),
+    )
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    convert_field_to_two_characters(env, sql.Identifier("month_from"))
+    convert_field_to_two_characters(env, sql.Identifier("month_to"))

--- a/account_payment_term_partner_holiday/models/account_move.py
+++ b/account_payment_term_partner_holiday/models/account_move.py
@@ -1,7 +1,7 @@
 # Copyright 2021 Tecnativa - Víctor Martínez
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
-from odoo import models
+from odoo import api, models
 
 
 class AccountMove(models.Model):
@@ -12,3 +12,21 @@ class AccountMove(models.Model):
         if self.partner_id:
             _self = self.with_context(move_partner_id=self.partner_id.id)
         super(AccountMove, _self)._recompute_payment_terms_lines()
+
+    @api.onchange("invoice_date_due")
+    def _onchange_invoice_date_due_account_payment_term_partner_holiday(self):
+        if self.invoice_date_due and self.partner_id:
+            new_invoice_date_due = self.partner_id._get_valid_due_date(
+                self.invoice_date_due
+            )
+            if new_invoice_date_due != self.invoice_date_due:
+                self.invoice_date_due = new_invoice_date_due
+
+    def action_post(self):
+        """Inject a context for getting the partner when computing payment term.
+        The trade-off is that we should split the call to super record per record,
+        but it shouldn't impact in performance.
+        """
+        for item in self:
+            _item = item.with_context(move_partner_id=item.partner_id.id)
+            return super(AccountMove, _item).action_post()

--- a/account_payment_term_partner_holiday/models/account_payment_term.py
+++ b/account_payment_term_partner_holiday/models/account_payment_term.py
@@ -1,8 +1,6 @@
 # Copyright 2021 Tecnativa - Víctor Martínez
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
-from dateutil.relativedelta import relativedelta
-
 from odoo import fields, models
 
 
@@ -17,12 +15,9 @@ class AccountPaymentTerm(models.Model):
             partner = self.env["res.partner"].browse(partner_id)
             result2 = []
             for item in result:
-                date_item = item[0]
-                is_date_in_holiday = partner.is_date_in_holiday(date_item)
-                if is_date_in_holiday:
-                    next_date = is_date_in_holiday[1]
-                    next_date += relativedelta(days=1)
-                    result2.append((fields.Date.to_string(next_date), item[1]))
+                new_date_item = partner._get_valid_due_date(item[0])
+                if new_date_item != item[0]:
+                    result2.append((fields.Date.to_string(new_date_item), item[1]))
                 else:
                     result2.append(item)
             result = result2

--- a/account_payment_term_partner_holiday/models/res_partner.py
+++ b/account_payment_term_partner_holiday/models/res_partner.py
@@ -1,5 +1,10 @@
 # Copyright 2021 Tecnativa - Víctor Martínez
+# Copyright 2021 Tecnativa - João Marques
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+import calendar
+
+from dateutil.relativedelta import relativedelta
 
 from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
@@ -16,33 +21,34 @@ class ResPartner(models.Model):
         auto_join=True,
     )
 
+    def _get_valid_due_date(self, date):
+        if isinstance(date, str):
+            date = fields.Date.from_string(date)
+        is_date_in_holiday = self.is_date_in_holiday(date)
+        while is_date_in_holiday:
+            date = is_date_in_holiday[1] + relativedelta(days=1)
+            is_date_in_holiday = self.is_date_in_holiday(date)
+        return date
+
     def is_date_in_holiday(self, date):
         if isinstance(date, str):
             date = fields.Date.from_string(date)
-        res = self.holiday_ids.filtered(
-            lambda x: int(x.month_from) <= date.month
-            and int(x.month_to) >= date.month
-            and int(x.day_from) <= date.day
-            and int(x.day_to) >= date.day
-        )
-        if bool(res):
-            res = res[0]
-            res_date_to = False
-            day_to = int(res.day_to)
-            while not res_date_to:
-                try:
-                    res_date_to = fields.Date.from_string(
-                        "%s-%s-%s" % (date.year, res.month_to, day_to)
-                    )
-                except ValueError:
-                    day_to -= 1
-            return [
-                fields.Date.from_string(
-                    "%s-%s-%s" % (date.year, res.month_from, res.day_from)
-                ),
-                res_date_to,
-            ]
+        for holiday in self.commercial_partner_id.holiday_ids:
+            holiday_start_date = self._generate_field_date(
+                date.year, int(holiday.month_from), int(holiday.day_from)
+            )
+            holiday_end_date = self._generate_field_date(
+                date.year, int(holiday.month_to), int(holiday.day_to)
+            )
+            if date >= holiday_start_date and date <= holiday_end_date:
+                return [holiday_start_date, holiday_end_date]
         return False
+
+    def _generate_field_date(self, year, month, day):
+        # When the user selects a date that does not exist, assume the last day
+        # for that month
+        days = (day, max(calendar.monthrange(year, month)))
+        return fields.Date.from_string("%s-%s-%s" % (year, month, min(days)))
 
 
 class ResPartnerHoliday(models.Model):
@@ -57,15 +63,15 @@ class ResPartnerHoliday(models.Model):
     @api.model
     def _selection_months(self):
         return [
-            ("1", _("January")),
-            ("2", _("February")),
-            ("3", _("March")),
-            ("4", _("April")),
-            ("5", _("May")),
-            ("6", _("June")),
-            ("7", _("July")),
-            ("8", _("August")),
-            ("9", _("September")),
+            ("01", _("January")),
+            ("02", _("February")),
+            ("03", _("March")),
+            ("04", _("April")),
+            ("05", _("May")),
+            ("06", _("June")),
+            ("07", _("July")),
+            ("08", _("August")),
+            ("09", _("September")),
             ("10", _("October")),
             ("11", _("November")),
             ("12", _("December")),
@@ -91,6 +97,14 @@ class ResPartnerHoliday(models.Model):
     month_to = fields.Selection(
         selection="_selection_months", string="Month to", required=True,
     )
+
+    _sql_constraints = [
+        (
+            "month_consistency",
+            "CHECK(month_from <= month_to)",
+            "Month from should be higher than month from",
+        ),
+    ]
 
     @api.constrains("day_from", "month_from", "day_to", "month_to")
     def _check_from_end_dates(self):

--- a/account_payment_term_partner_holiday/readme/ROADMAP.rst
+++ b/account_payment_term_partner_holiday/readme/ROADMAP.rst
@@ -1,0 +1,1 @@
+* Due dates for invoices are not updated when new holidays are created after.

--- a/account_payment_term_partner_holiday/static/description/index.html
+++ b/account_payment_term_partner_holiday/static/description/index.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta name="generator" content="Docutils 0.15.1: http://docutils.sourceforge.net/" />
+<meta name="generator" content="Docutils: http://docutils.sourceforge.net/" />
 <title>Account Payment Term Partner Holiday</title>
 <style type="text/css">
 
@@ -374,11 +374,12 @@ partner so as not to use those periods as the due date on invoices.</p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
 <li><a class="reference internal" href="#usage" id="id1">Usage</a></li>
-<li><a class="reference internal" href="#bug-tracker" id="id2">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="id3">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="id4">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="id5">Contributors</a></li>
-<li><a class="reference internal" href="#maintainers" id="id6">Maintainers</a></li>
+<li><a class="reference internal" href="#known-issues-roadmap" id="id2">Known issues / Roadmap</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="id3">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="id4">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="id5">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="id6">Contributors</a></li>
+<li><a class="reference internal" href="#maintainers" id="id7">Maintainers</a></li>
 </ul>
 </li>
 </ul>
@@ -394,8 +395,14 @@ Invoices’ and create or edit some record.</li>
 <li>If the computed due date is inside a holidays period, it’s moved to the first available date.</li>
 </ol>
 </div>
+<div class="section" id="known-issues-roadmap">
+<h1><a class="toc-backref" href="#id2">Known issues / Roadmap</a></h1>
+<ul class="simple">
+<li>Due dates for invoices are not updated when new holidays are created after.</li>
+</ul>
+</div>
 <div class="section" id="bug-tracker">
-<h1><a class="toc-backref" href="#id2">Bug Tracker</a></h1>
+<h1><a class="toc-backref" href="#id3">Bug Tracker</a></h1>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/account-payment/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us smashing it by providing a detailed and welcomed
@@ -403,15 +410,15 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h1><a class="toc-backref" href="#id3">Credits</a></h1>
+<h1><a class="toc-backref" href="#id4">Credits</a></h1>
 <div class="section" id="authors">
-<h2><a class="toc-backref" href="#id4">Authors</a></h2>
+<h2><a class="toc-backref" href="#id5">Authors</a></h2>
 <ul class="simple">
 <li>Tecnativa</li>
 </ul>
 </div>
 <div class="section" id="contributors">
-<h2><a class="toc-backref" href="#id5">Contributors</a></h2>
+<h2><a class="toc-backref" href="#id6">Contributors</a></h2>
 <ul class="simple">
 <li><a class="reference external" href="https://www.tecnativa.com">Tecnativa</a>:<ul>
 <li>Víctor Martínez</li>
@@ -421,7 +428,7 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h2><a class="toc-backref" href="#id6">Maintainers</a></h2>
+<h2><a class="toc-backref" href="#id7">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
 <a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose

--- a/account_payment_term_partner_holiday/tests/test_partner_holiday.py
+++ b/account_payment_term_partner_holiday/tests/test_partner_holiday.py
@@ -1,9 +1,12 @@
 # Copyright 2021 Tecnativa - Víctor Martínez
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+import psycopg2
+
 from odoo import fields
 from odoo.tests import common
 from odoo.tests.common import Form
+from odoo.tools.misc import mute_logger
 
 
 class TestPartnerHoliday(common.TransactionCase):
@@ -18,13 +21,46 @@ class TestPartnerHoliday(common.TransactionCase):
                         0,
                         {
                             "day_from": "1",
-                            "month_from": "2",
+                            "month_from": "02",
                             "day_to": "31",
-                            "month_to": "2",
+                            "month_to": "02",
                         },
-                    )
+                    ),
+                    (
+                        0,
+                        0,
+                        {
+                            "day_from": "1",
+                            "month_from": "03",
+                            "day_to": "1",
+                            "month_to": "04",
+                        },
+                    ),
+                    (
+                        0,
+                        0,
+                        {
+                            "day_from": "12",
+                            "month_from": "06",
+                            "day_to": "13",
+                            "month_to": "06",
+                        },
+                    ),
+                    (
+                        0,
+                        0,
+                        {
+                            "day_from": "15",
+                            "month_from": "06",
+                            "day_to": "16",
+                            "month_to": "06",
+                        },
+                    ),
                 ],
             }
+        )
+        self.partner_1_child = self.env["res.partner"].create(
+            {"name": "Partner child", "parent_id": self.partner_1.id, "type": "invoice"}
         )
         self.partner_2 = self.env["res.partner"].create({"name": "Partner test 2"})
         self.payment_term_immediate = self.env["account.payment.term"].create(
@@ -84,6 +120,17 @@ class TestPartnerHoliday(common.TransactionCase):
             }
         )
 
+    def test_check_partner_holiday_constraint(self):
+        vals = {
+            "partner_id": self.partner_2.id,
+            "day_from": "1",
+            "month_from": "12",
+            "day_to": "1",
+            "month_to": "01",
+        }
+        with self.assertRaises(psycopg2.IntegrityError), mute_logger("odoo.sql_db"):
+            self.env["res.partner.holiday"].create(vals)
+
     def test_check_dates_in_partner_1(self):
         self.assertEqual(
             self.partner_1.is_date_in_holiday(fields.Date.from_string("2021-02-01")),
@@ -93,7 +140,22 @@ class TestPartnerHoliday(common.TransactionCase):
             ],
         )
         self.assertEqual(
-            self.partner_1.is_date_in_holiday(fields.Date.from_string("2021-02-10")),
+            self.partner_1.is_date_in_holiday(fields.Date.from_string("2021-03-01")),
+            [
+                fields.Date.from_string("2021-03-01"),
+                fields.Date.from_string("2021-04-01"),
+            ],
+        )
+        self.assertFalse(
+            self.partner_1.is_date_in_holiday(fields.Date.from_string("2021-04-02"))
+        )
+
+    def test_check_dates_in_partner_1_only_february(self):
+        self.assertEqual(len(self.partner_1.holiday_ids), 4)
+        self.partner_1.holiday_ids.filtered(lambda x: x.month_from == "03").unlink()
+        self.assertEqual(len(self.partner_1.holiday_ids), 3)
+        self.assertEqual(
+            self.partner_1.is_date_in_holiday(fields.Date.from_string("2021-02-01")),
             [
                 fields.Date.from_string("2021-02-01"),
                 fields.Date.from_string("2021-02-28"),
@@ -114,63 +176,97 @@ class TestPartnerHoliday(common.TransactionCase):
             self.partner_2.is_date_in_holiday(fields.Date.from_string("2021-02-10"))
         )
         self.assertFalse(
-            self.partner_2.is_date_in_holiday(fields.Date.from_string("2021-03-01"))
+            self.partner_2.is_date_in_holiday(fields.Date.from_string("2021-04-02"))
         )
 
-    def _create_invoice_form(self, partner_id):
-        invoice_form = Form(
+    def _set_invoice_form(self, partner_id, date):
+        return Form(
             self.env["account.move"].with_context(
                 default_journal_id=self.journal.id,
                 default_partner_id=partner_id,
                 default_type="out_invoice",
-                default_invoice_date="2021-02-01",
+                default_invoice_date=date,
             ),
         )
+
+    def test_invoice_payment_term_partner_1(self):
+        invoice_form = self._set_invoice_form(self.partner_1.id, "2021-02-01")
+        invoice_form.invoice_payment_term_id = self.payment_term_immediate
+        self.assertEqual(
+            invoice_form.invoice_date_due, fields.Date.from_string("2021-04-02")
+        )
+        invoice_form.invoice_payment_term_id = self.payment_term_10_days
         with invoice_form.invoice_line_ids.new() as line:
             line.product_id = self.product
-        return invoice_form
-
-    def test_invoice_payment_term_partner_1_payment_term_immediate(self):
-        invoice_form = self._create_invoice_form(self.partner_1.id)
-        invoice_form.invoice_payment_term_id = self.payment_term_immediate
         invoice = invoice_form.save()
-        invoice_move_line = invoice.line_ids.filtered("date_maturity")
         self.assertEqual(
-            invoice_move_line.date_maturity, fields.Date.from_string("2021-03-01")
+            invoice.invoice_date_due, fields.Date.from_string("2021-04-02")
         )
-
-    def test_invoice_payment_term_partner_1_payment_term_10_days(self):
-        invoice_form = self._create_invoice_form(self.partner_1.id)
+        # Set to 2021-04-01
+        invoice_form = self._set_invoice_form(self.partner_1.id, "2021-04-01")
         invoice_form.invoice_payment_term_id = self.payment_term_10_days
+        with invoice_form.invoice_line_ids.new() as line:
+            line.product_id = self.product
         invoice = invoice_form.save()
-        invoice_move_line = invoice.line_ids.filtered("date_maturity")
         self.assertEqual(
-            invoice_move_line.date_maturity, fields.Date.from_string("2021-03-01")
+            invoice.invoice_date_due, fields.Date.from_string("2021-04-11")
         )
 
-    def test_invoice_payment_term_partner_1_default(self):
-        invoice_form = self._create_invoice_form(self.partner_1.id)
-        invoice_form.invoice_date_due = "2021-02-01"
-        invoice = invoice_form.save()
-        invoice_move_line = invoice.line_ids.filtered("date_maturity")
-        self.assertEqual(
-            invoice_move_line.date_maturity, fields.Date.from_string("2021-02-01")
-        )
-
-    def test_invoice_payment_term_partner_2_payment_term_immediate(self):
-        invoice_form = self._create_invoice_form(self.partner_2.id)
+    def test_invoice_payment_term_partner_1_child(self):
+        invoice_form = self._set_invoice_form(self.partner_1_child.id, "2021-02-01")
         invoice_form.invoice_payment_term_id = self.payment_term_immediate
-        invoice = invoice_form.save()
-        invoice_move_line = invoice.line_ids.filtered("date_maturity")
         self.assertEqual(
-            invoice_move_line.date_maturity, fields.Date.from_string("2021-02-01")
+            invoice_form.invoice_date_due, fields.Date.from_string("2021-04-02")
+        )
+        invoice_form.invoice_payment_term_id = self.payment_term_10_days
+        self.assertEqual(
+            invoice_form.invoice_date_due, fields.Date.from_string("2021-04-02")
+        )
+        # Set to 2021-04-01
+        invoice_form = self._set_invoice_form(self.partner_1_child.id, "2021-04-01")
+        invoice_form.invoice_payment_term_id = self.payment_term_10_days
+        with invoice_form.invoice_line_ids.new() as line:
+            line.product_id = self.product
+        invoice = invoice_form.save()
+        self.assertEqual(
+            invoice.invoice_date_due, fields.Date.from_string("2021-04-11")
         )
 
-    def test_invoice_payment_term_partner_2_payment_term_10_days(self):
-        invoice_form = self._create_invoice_form(self.partner_2.id)
-        invoice_form.invoice_payment_term_id = self.payment_term_10_days
-        invoice = invoice_form.save()
-        invoice_move_line = invoice.line_ids.filtered("date_maturity")
+    def test_invoice_payment_term_partner_2(self):
+        invoice_form = self._set_invoice_form(self.partner_2.id, "2021-02-01")
+        invoice_form.invoice_payment_term_id = self.payment_term_immediate
         self.assertEqual(
-            invoice_move_line.date_maturity, fields.Date.from_string("2021-02-11")
+            invoice_form.invoice_date_due, fields.Date.from_string("2021-02-01")
+        )
+        invoice_form.invoice_payment_term_id = self.payment_term_10_days
+        with invoice_form.invoice_line_ids.new() as line:
+            line.product_id = self.product
+        invoice = invoice_form.save()
+        self.assertEqual(
+            invoice.invoice_date_due, fields.Date.from_string("2021-02-11")
+        )
+
+    def test_partner_1_invoice_date_june_13(self):
+        invoice_form = self._set_invoice_form(self.partner_1.id, "2021-06-13")
+        invoice_form.invoice_payment_term_id = self.payment_term_immediate
+        self.assertEqual(
+            invoice_form.invoice_date_due, fields.Date.from_string("2021-06-14")
+        )
+
+    def test_partner_1_get_valid_due_date(self):
+        self.assertEqual(
+            self.partner_1._get_valid_due_date(fields.Date.from_string("2021-01-01")),
+            fields.Date.from_string("2021-01-01"),
+        )
+        self.assertEqual(
+            self.partner_1._get_valid_due_date(fields.Date.from_string("2021-02-01")),
+            fields.Date.from_string("2021-04-02"),
+        )
+        self.assertEqual(
+            self.partner_1._get_valid_due_date(fields.Date.from_string("2021-06-12")),
+            fields.Date.from_string("2021-06-14"),
+        )
+        self.assertEqual(
+            self.partner_1._get_valid_due_date(fields.Date.from_string("2021-06-14")),
+            fields.Date.from_string("2021-06-14"),
         )

--- a/account_payment_term_partner_holiday/views/res_partner_view.xml
+++ b/account_payment_term_partner_holiday/views/res_partner_view.xml
@@ -6,7 +6,10 @@
         <field name="inherit_id" ref="account.view_partner_property_form" />
         <field name="arch" type="xml">
             <field name="property_payment_term_id" position="after">
-                <field name="holiday_ids">
+                <field
+                    name="holiday_ids"
+                    attrs="{'invisible': [('parent_id','!=', False)]}"
+                >
                     <tree editable="bottom">
                         <field name="day_from" />
                         <field name="month_from" />


### PR DESCRIPTION
Improve `is_date_in_holiday()` to filtered correctly when day_to is less than date to compare.
Improve is_date_in_holiday() to work fine in child partners
Hide holidays in partner view to child partners.
Change `month_from` and `month_to` fields to convert in 2 characters to order correctly holidays + Script migration

FWP from 12.0: https://github.com/OCA/account-payment/pull/429

Please @pedrobaeza and @joao-p-marques can you review it?

@Tecnativa TT30526
