### PR TITLE
[13.0][IMP+FIX] account_payment_term_partner_holiday: Change addon to depends account_payment_term_extension

### DIFF
--- a/account_payment_term_partner_holiday/__manifest__.py
+++ b/account_payment_term_partner_holiday/__manifest__.py
@@ -9,7 +9,7 @@
     "license": "AGPL-3",
     "application": False,
     "installable": True,
-    "depends": ["account"],
+    "depends": ["account_payment_term_extension"],
     "maintainers": ["victoralmau"],
     "development_status": "Production/Stable",
     "data": ["security/ir.model.access.csv", "views/res_partner_view.xml"],

--- a/account_payment_term_partner_holiday/models/account_move.py
+++ b/account_payment_term_partner_holiday/models/account_move.py
@@ -15,7 +15,19 @@ class AccountMove(models.Model):
 
     @api.onchange("invoice_date_due")
     def _onchange_invoice_date_due_account_payment_term_partner_holiday(self):
-        if self.invoice_date_due and self.partner_id:
+        """Recompute the due date to the next available date according to
+        the holiday periods set in the partner.
+
+        It must only be re-calculated when a payment term is not set.
+        This prevents the due date to be changed again and that another
+        given number of days are added according to what is set on the
+        payment term.
+        """
+        if (
+            self.invoice_date_due
+            and self.partner_id
+            and not self.invoice_payment_term_id
+        ):
             new_invoice_date_due = self.partner_id._get_valid_due_date(
                 self.invoice_date_due
             )

--- a/account_payment_term_partner_holiday/models/account_payment_term.py
+++ b/account_payment_term_partner_holiday/models/account_payment_term.py
@@ -8,16 +8,27 @@ class AccountPaymentTerm(models.Model):
     _inherit = "account.payment.term"
 
     def compute(self, value, date_ref=False, currency=None):
+        """Compute the due date taking into account the holiday periods
+        set in the partner.
+
+        Once an initial date resulting of the payment term is computed,
+        compute the first available date after that.
+        Then, apply_payment_days() and apply_holidays() to prevent
+        incompatibilities.
+        """
         result = super().compute(value=value, date_ref=date_ref, currency=currency)
         ctx = self.env.context
         partner_id = ctx.get("move_partner_id", ctx.get("default_partner_id"))
         if partner_id:
             partner = self.env["res.partner"].browse(partner_id)
             result2 = []
-            for item in result:
-                new_date_item = partner._get_valid_due_date(item[0])
-                if new_date_item != item[0]:
-                    result2.append((fields.Date.to_string(new_date_item), item[1]))
+            for key, item in enumerate(result):
+                next_date = partner._get_valid_due_date(item[0])
+                if next_date != item[0]:
+                    line = self.line_ids[key]
+                    next_date = self.apply_payment_days(line, next_date)
+                    next_date = self.apply_holidays(next_date)
+                    result2.append((fields.Date.to_string(next_date), item[1]))
                 else:
                     result2.append(item)
             result = result2


### PR DESCRIPTION
FWP from 12.0: https://github.com/OCA/account-payment/pull/432

Changes:
- [IMP] Change addon to depends `account_payment_term_extension` 
- [FIX] Change the way to set correctly due date according payment term lines definition (not +1 day always).

It's necessary to not use `_get_valid_due_date()` in `compute()` payment term process to prevent incorrect dates (before if we set some date, allways return +1 day according to "last" holiday period but what happen when +10 days according to payment term line or if payment term line set custom payment days?), we only use these function when due date change manually (not if date have change according to payment term set).

PD: In 13.0 is different because we only set payment term OR due date in invoice, it's not possible to change both.

**Some examples to understand these changes.**

Partner holidays: From 2021-01-01 to 2021-01-15
Payment term A: +0 days
Payment term B: +10 days
Payment term C: custom payment date: 5 or 10
Payment term D: have holiday in 2021-01-16, date postponed is 2021-03-01

| Invoice date  | Payment term  | Before due date | Current due date |
| ------------- | ------------- | --------------- | ---------------- |
| 2021-01-01 | Payment term A | 2021-01-16 | 2021-01-16 |
| 2021-01-01 | Payment term B | 2021-01-16 | 2021-01-16 |
| 2021-01-01 | Payment term C |  | 2021-02-05 |
| 2021-01-01 | Payment term D |  | 2021-03-01 |

Invoice B: Before these change it's ok, but now is 2021-01-26.
Invoice C: Before these change expected due date was 2021-01-16 but it's incorrect, we can't re-create all possibilities in override function AND it's reason to allway re-compute only when new due date isn't initial due date.
Invoice D: The only way to be sure that generated due date is correct is re-compute at end.

Please @pedrobaeza and @joao-p-marques can you review it?

@Tecnativa TT31110