### PR TITLE
[FIX] account_cash_invoice: wizards and account_bank_statement model

### DIFF
--- a/account_cash_invoice/models/__init__.py
+++ b/account_cash_invoice/models/__init__.py
@@ -1,3 +1,4 @@
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 
 from . import account_bank_statement_line
+from . import account_bank_statement

--- a/account_cash_invoice/models/account_bank_statement.py
+++ b/account_cash_invoice/models/account_bank_statement.py
@@ -1,0 +1,20 @@
+# Copyright 2021 Creu Blanca
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class AccountBankStatement(models.Model):
+
+    _inherit = "account.bank.statement"
+
+    def button_post(self):
+        lines_of_moves_to_reconcile = self.line_ids.filtered(
+            lambda line: line.move_id.state != "posted" and line.invoice_id
+        )
+        result = super(AccountBankStatement, self).button_post()
+        for line in lines_of_moves_to_reconcile:
+            (line.invoice_id.line_ids | line.move_id.line_ids).filtered(
+                lambda l: l.account_internal_type in ("receivable", "payable")
+            ).reconcile()
+        return result

--- a/account_cash_invoice/tests/test_pay_invoice.py
+++ b/account_cash_invoice/tests/test_pay_invoice.py
@@ -108,10 +108,10 @@ class TestSessionPayInvoice(SavepointCase):
         inv_lines |= self.invoice_out.line_ids.filtered(
             lambda line: line.account_id.user_type_id.type in ("receivable", "payable")
         )
-        for st_line, inv_line in zip(statement.line_ids, inv_lines):
-            st_line.reconcile([{"id": inv_line.id}], [])
         statement.button_validate()
+        self.invoice_out.flush()
         self.invoice_out.refresh()
         self.assertEqual(self.invoice_out.amount_residual, 0.0)
+        self.invoice_in.flush()
         self.invoice_in.refresh()
         self.assertEqual(self.invoice_in.amount_residual, 0.0)

--- a/account_cash_invoice/wizard/cash_invoice_in.py
+++ b/account_cash_invoice/wizard/cash_invoice_in.py
@@ -94,6 +94,9 @@ class CashInvoiceIn(models.TransientModel):
                 "invoice_id": self.invoice_id.id,
                 "ref": self.invoice_id.name,
                 "partner_id": self.invoice_id.partner_id.id,
+                "counterpart_account_id": self.invoice_id.line_ids.filtered(
+                    lambda l: l.account_internal_type in ("receivable", "payable")
+                ).account_id.id,
             }
         )
         return res

--- a/account_cash_invoice/wizard/cash_invoice_out.py
+++ b/account_cash_invoice/wizard/cash_invoice_out.py
@@ -102,6 +102,9 @@ class CashInvoiceOut(models.TransientModel):
                 "invoice_id": self.invoice_id.id,
                 "ref": self.invoice_id.name,
                 "partner_id": self.invoice_id.partner_id.id,
+                "counterpart_account_id": self.invoice_id.line_ids.filtered(
+                    lambda l: l.account_internal_type in ("receivable", "payable")
+                ).account_id.id,
             }
         )
         return res


### PR DESCRIPTION
As can be seen in the attached videos, this PR fixes the "Reconciled Entries" button as well as the statement lines:

Previously:
![Before](https://user-images.githubusercontent.com/85160344/148930666-75d1443f-ba67-4fcf-b63c-4b1f0f9a1a6f.gif)
Applying changes:
![After](https://user-images.githubusercontent.com/85160344/148930651-6c147bb2-e280-4880-8399-2ded294737dd.gif)

- The field "counterpart_account_id" is added on cash_invoice_in and cash_invoice_out wizards.
- The function "button_post" is added on account_bank_statement model.