### PR TITLE
[14.0][FIX] account_payment_return: use journal return account

### DIFF
--- a/account_payment_return/models/payment_return.py
+++ b/account_payment_return/models/payment_return.py
@@ -176,7 +176,7 @@ class PaymentReturn(models.Model):
             "name": move.ref,
             "debit": 0.0,
             "credit": total_amount,
-            "account_id": self.journal_id.default_account_id.id,
+            "account_id": self.journal_id.payment_credit_account_id.id,
             "move_id": move.id,
             "journal_id": move.journal_id.id,
         }


### PR DESCRIPTION
This fix allows to reconcile the journal entry created from a payment.return with the selected bank. Without the fix the counterpart used in the journal entry is the default_account_id, the fix replaces this account with the payment_credit_account_id which is reconcilable with the bank statement line.