### PR TITLE
[14.0][FIX] account_payment_credit_card: fix '_post' signature

### DIFF
--- a/account_payment_credit_card/models/account_move.py
+++ b/account_payment_credit_card/models/account_move.py
@@ -7,7 +7,7 @@ from odoo import models
 class AccountMove(models.Model):
     _inherit = "account.move"
 
-    def _post(self, soft=False):
+    def _post(self, soft=True):
         for move in self:
             result = []
             # Check whether journal has Transfer AP to Credit Card


### PR DESCRIPTION
The expected signature is `_post(soft=True)`: https://github.com/odoo/odoo/blob/612f4917efe98e5cb6f3c184728eb245a1ca0278/addons/account/models/account_move.py#L2583