### PR TITLE
[14.0][FIX] Call onchange in create because invoice creation otherwise skips it

### DIFF
--- a/account_cash_discount_base/models/account_move.py
+++ b/account_cash_discount_base/models/account_move.py
@@ -246,5 +246,13 @@ class AccountMove(models.Model):
     @api.model
     def create(self, values):
         rec = super().create(values)
-        rec._onchange_payment_term_discount_options()
+        payment_term = rec.invoice_payment_term_id
+        if not payment_term or self.move_type not in DISCOUNT_ALLOWED_TYPES:
+            return rec
+
+        if not rec.discount_percent:
+            rec.discount_percent = payment_term.discount_percent
+
+        if not rec.discount_delay:
+            rec.discount_delay = payment_term.discount_delay
         return rec

--- a/account_cash_discount_base/models/account_move.py
+++ b/account_cash_discount_base/models/account_move.py
@@ -247,12 +247,10 @@ class AccountMove(models.Model):
     def create(self, values):
         rec = super().create(values)
         payment_term = rec.invoice_payment_term_id
-        if not payment_term or self.move_type not in DISCOUNT_ALLOWED_TYPES:
+        if not payment_term or rec.move_type not in DISCOUNT_ALLOWED_TYPES:
             return rec
 
-        if not rec.discount_percent:
-            rec.discount_percent = payment_term.discount_percent
-
-        if not rec.discount_delay:
-            rec.discount_delay = payment_term.discount_delay
+        for field in ("discount_percent", "discount_delay"):
+            if field not in values:
+                rec[field] = payment_term[field]
         return rec

--- a/account_cash_discount_base/models/account_move.py
+++ b/account_cash_discount_base/models/account_move.py
@@ -242,3 +242,9 @@ class AccountMove(models.Model):
             payment_term = partner.property_supplier_payment_term_id
             res["invoice_payment_term_id"] = payment_term.id
         return res
+
+    @api.model
+    def create(self, values):
+        rec = super().create(values)
+        rec._onchange_payment_term_discount_options()
+        return rec


### PR DESCRIPTION
If you specify a discount for a purchase.order the payment term will be copied to the account.move. This is bypassing the onchange trigger to calculate the discount values and days on the invoice. The values aren't calculated without manually switching the payment term on the invoice.