### PR TITLE
[FIX] account_payment_term_discount: cannot add extra amount

### DIFF
--- a/account_payment_term_discount/wizard/account_payment_register.py
+++ b/account_payment_term_discount/wizard/account_payment_register.py
@@ -62,20 +62,21 @@ class AccountPaymentRegister(models.TransientModel):
                         self.writeoff_account_id = discount_account.id
                         self.writeoff_label = "Payment Discount"
                     # customer is paying more
-                    elif abs(payment_difference) < discount_amt:
-
-                        self.payment_difference = abs(payment_difference)
-                        self.payment_difference_handling = "reconcile"
-                        self.writeoff_account_id = discount_account.id
-                        self.writeoff_label = "Payment Discount"
+                    elif payment_difference < discount_amt:
+                        if payment_difference > 0:
+                            self.payment_difference = discount_amt
+                            self.payment_difference_handling = "reconcile"
+                            self.writeoff_account_id = discount_account.id
+                            self.writeoff_label = "Payment Discount"
+                        elif payment_difference < 0:
+                            self.payment_difference = payment_difference
                     # ocustomer paying more than discount_amt
-                    elif abs(payment_difference) > discount_amt:
-
-                        self.payment_difference = abs(payment_difference)
+                    elif payment_difference > discount_amt:
+                        self.payment_difference = payment_difference
                         self.payment_difference_handling = "open"
                         self.writeoff_label = False
                     # customer paying more than discount_amt
-                    elif abs(payment_difference) == discount_amt and discount_amt > 0:
+                    elif payment_difference == discount_amt and discount_amt > 0:
 
                         self.payment_difference = abs(payment_difference)
                         self.payment_difference_handling = "reconcile"
@@ -84,7 +85,7 @@ class AccountPaymentRegister(models.TransientModel):
                 else:
                     self.payment_difference = payment_difference
 
-                self.amount = self.invoice_id.amount_residual - abs(
+                self.amount = self.invoice_id.amount_residual - (
                     self.payment_difference
                 )
 


### PR DESCRIPTION
If the payment difference is less than the invoice amount, it will follow the base functionality.
If the payment difference is in between discounted amount and invoice amount or payment difference is zero, the payment will be discounted amount.
If the payment difference is greater than the invoice amount, it will follow the base functionality.

Related Issue: https://github.com/OCA/account-payment/issues/470

cc: @SodexisTeam 