### PR TITLE
[FIX] account_due_list: Do not require administrator rights

### DIFF
--- a/account_due_list/models/account_move_line.py
+++ b/account_due_list/models/account_move_line.py
@@ -35,7 +35,7 @@ class AccountMoveLine(models.Model):
     def fields_view_get(
         self, view_id=None, view_type="form", toolbar=False, submenu=False
     ):
-        model_data_obj = self.env["ir.model.data"]
+        model_data_obj = self.env["ir.model.data"].sudo()
         ids = model_data_obj.search(
             [("module", "=", "account_due_list"), ("name", "=", "view_payments_tree")]
         )


### PR DESCRIPTION
We avoid having to give administrator rights to access Accounting/Payments and due list because the module needs to access the model ir.model_data