### PR TITLE
[14.0][FIX] account_payment_credit_card: create all lines on batch

### DIFF
--- a/account_payment_credit_card/models/account_move.py
+++ b/account_payment_credit_card/models/account_move.py
@@ -35,6 +35,7 @@ class AccountMove(models.Model):
                 # Check result list
                 if result:
                     # Create new move lines
-                    for vals in result:
-                        self.env["account.move.line"].create(vals)
+                    self.env["account.move.line"].with_context(
+                        skip_account_move_synchronization=True
+                    ).create(result)
         return super(AccountMove, self)._post(soft)


### PR DESCRIPTION
this commit avoid error unbalanced journal
add context skip_account_move_synchronization for skip exception on https://github.com/odoo/odoo/blob/2851f3b5a7caf3530777071a3641ed00ea264ced/addons/account/models/account_payment.py#L709

This bug is present into V13 on PR https://github.com/OCA/account-payment/pull/285 @Nikul-Chaudhary you can review

CC @bosd
Fixed #482