### PR TITLE
Introduces the concept of "reason nature" to indicate that a return reason means success

### DIFF
--- a/account_payment_return/models/payment_return_reason.py
+++ b/account_payment_return/models/payment_return_reason.py
@@ -10,6 +10,10 @@ class PaymentReturnReason(models.Model):
 
     code = fields.Char()
     name = fields.Char(string="Reason", translate=True)
+    reason_nature = fields.Selection([
+        ('success',             'Success'),
+        ('generic_failure',     'Generic Failure'),
+        ], string="Return reason nature", required=True, default='generic_failure',)
 
     @api.model
     def name_search(self, name, args=None, operator="ilike", limit=100):

--- a/account_payment_return/views/payment_return_view.xml
+++ b/account_payment_return/views/payment_return_view.xml
@@ -67,10 +67,12 @@
                                 widget="one2many_list"
                                 context="{'default_date': date}"
                             >>
-                                <tree string="Payment return lines" editable="top">
+                                <tree string="Payment return lines" editable="top"
+                                        decoration-success="reason_nature=='success'" decoration-danger="reason_nature!='success'">
                                     <field name="date" />
                                     <field name="concept" />
                                     <field name="reason_id" />
+                                    <field name="reason_nature" invisible="1" />
                                     <field name="reason_additional_information" />
                                     <field name="partner_name" invisible="1" />
                                     <field name="partner_id" />


### PR DESCRIPTION
Imported direct  debit returns may include every transaction, including those that ended up in success (in SEPA this is
indicated by a reason code '0000'). This pull request will avoid generating reversions for transactions that
have a return reason_nature=='success'.