### PR TITLE
[13.0][FIX] account_payment_term_partner_holiday: Allow action_post() from moves with multi-record

### DIFF
--- a/account_payment_term_partner_holiday/models/account_move.py
+++ b/account_payment_term_partner_holiday/models/account_move.py
@@ -41,4 +41,5 @@ class AccountMove(models.Model):
         """
         for item in self:
             _item = item.with_context(move_partner_id=item.partner_id.id)
-            return super(AccountMove, _item).action_post()
+            super(AccountMove, _item).action_post()
+        return True


### PR DESCRIPTION
Allow `action_post()` from moves with multi-record

Related to https://github.com/OCA/account-payment/pull/523#discussion_r925182193

Please @chienandalu and @LudLaf can you review it?

@Tecnativa TT37271