### PR TITLE
[FIX] account_payment_batch_process: payment_method_id wrong domain

### DIFF
--- a/account_payment_batch_process/wizard/account_payment_register.xml
+++ b/account_payment_batch_process/wizard/account_payment_register.xml
@@ -83,11 +83,6 @@
             <xpath expr="//field[@name='amount']" position="attributes">
                 <attribute name="invisible">context.get('batch', False)</attribute>
             </xpath>
-            <xpath expr="//field[@name='payment_method_id']" position="attributes">
-                <attribute
-                    name="domain"
-                >[('payment_type', '=', payment_type)]</attribute>
-            </xpath>
             <xpath expr="//field[@name='communication']" position="after">
                 <field
                     name="cheque_amount"


### PR DESCRIPTION
Odoo's restriction to select the types of payment methods in Journal are removed with this domain at the Register payment window in Invoice.

cc: @SodexisTeam 