### PR TITLE
[12.0] FIX account_payment_select_cost_account when setting to draft payment

### DIFF
--- a/account_payment_select_cost_account/models/account_payment.py
+++ b/account_payment_select_cost_account/models/account_payment.py
@@ -16,3 +16,10 @@ class Payment(models.Model):
         if self.force_destination_account_id:
             vals['account_id'] = self.force_destination_account_id.id
         return vals
+
+    @api.multi
+    def action_draft(self):
+        res = super(Payment, self).action_draft()
+        for p in self:
+            if not p.force_destination_account_id and p.destination_account_id:
+                p.force_destination_account_id = p.destination_account_id.id


### PR DESCRIPTION
Steps:
 - Register a supplier invoice and "register payment"
 - Go to Vendors > Payments and select the created payment
 - Cancel, Set to draft and Edit

Observed: you can't save because "Cost account" is empty