### PR TITLE
[IMP] account_payment_notification: display envelope

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Do NOT update manually; changes here will be overwritten by Copier
-_commit: v1.11.0
+_commit: v1.11.1
 _src_path: gh:oca/oca-addons-repo-template
 ci: GitHub
 dependency_installation_mode: PIP

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -104,7 +104,7 @@ repos:
           - --settings=.
         exclude: /__init__\.py$
   - repo: https://github.com/acsone/setuptools-odoo
-    rev: 3.0.3
+    rev: 3.1.8
     hooks:
       - id: setuptools-odoo-make-default
       - id: setuptools-odoo-get-requirements
@@ -113,7 +113,7 @@ repos:
           - requirements.txt
           - --header
           - "# generated from manifests external_dependencies"
-  - repo: https://gitlab.com/PyCQA/flake8
+  - repo: https://github.com/PyCQA/flake8
     rev: 3.9.2
     hooks:
       - id: flake8

--- a/account_payment_notification/models/account_payment.py
+++ b/account_payment_notification/models/account_payment.py
@@ -54,13 +54,16 @@ class AccountPayment(models.Model):
     def _notify_sent_payments_email(self):
         """Notify sent payments by email."""
         mt_comment = self.env.ref("mail.mt_comment")
-        tpl = self.env.ref(
-            "account_payment_notification.mail_template_notification"
-        ).with_context(default_subtype_id=mt_comment.id)
+        tpl = self.env.ref("account_payment_notification.mail_template_notification")
         assert tpl.model == self._name, "Template has wrong model!?"
         for payment in self:
             # TODO Batch per lang if possible
-            tpl.send_mail(payment.id, force_send=False)
+            payment.message_post_with_template(
+                tpl.id,
+                composition_mode="mass_post",
+                subtype_id=mt_comment.id,
+                notify=True,
+            )
 
     def _notify_sent_payments_sms(self):
         """Notify sent payments by sms."""


### PR DESCRIPTION
Before this patch, generated emails didn't produce notification records. Thus, the message didn't display sent status.

![imagen](https://user-images.githubusercontent.com/973709/200837997-8d0d8a3a-4ecd-4140-b527-42e815c75060.png)


Instead of mass mailing, we use now the mass post system. This way, notifications appear as usual.

![imagen](https://user-images.githubusercontent.com/973709/200838199-3d27ed2c-76d4-4c0f-a550-916a83003f10.png)


Some tests added to ensure this behavior persists.

@moduon MT-1232