### PR TITLE
[16] account_due_list to Production/Stable

### DIFF
--- a/account_due_list/__manifest__.py
+++ b/account_due_list/__manifest__.py
@@ -4,7 +4,7 @@
     "name": "Payments Due list",
     "version": "16.0.1.0.1",
     "category": "Generic Modules/Payment",
-    "development_status": "Beta",
+    "development_status": "Production/Stable",
     "author": "Odoo Community Association (OCA)",
     "summary": "List of open credits and debits, with due date",
     "website": "https://github.com/OCA/account-payment",


### PR DESCRIPTION
what about promoting the development status of this module to "production/stable"? After years of use, seems pretty mature for us and this is currently locking the status of dependent modules to "Beta"...

cc @pedrobaeza @JordiBForgeFlow @max3903 @ramiadavid @renatonlima @marcelsavegnago @antoniospneto 