### PR TITLE
[13.0][ADD]account_payment_term_restriction*

### DIFF
--- a/account_payment_term_restriction/__init__.py
+++ b/account_payment_term_restriction/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/account_payment_term_restriction/__manifest__.py
+++ b/account_payment_term_restriction/__manifest__.py
@@ -1,0 +1,13 @@
+# Copyright 2023 ForgeFlow S.L. (https://www.forgeflow.com)
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+{
+    "name": "Payment Term Restriction",
+    "version": "13.0.1.0.0",
+    "category": "Accounting & Finance",
+    "summary": "Restricts the usage of Payment Terms Journal Entries",
+    "author": "ForgeFlow, Odoo Community Association (OCA)",
+    "website": "https://github.com/OCA/account-payment",
+    "license": "LGPL-3",
+    "depends": ["account"],
+    "data": ["views/account_payment_term.xml"],
+}

--- a/account_payment_term_restriction/models/__init__.py
+++ b/account_payment_term_restriction/models/__init__.py
@@ -1,0 +1,2 @@
+from . import account_move
+from . import account_payment_term

--- a/account_payment_term_restriction/models/account_move.py
+++ b/account_payment_term_restriction/models/account_move.py
@@ -1,0 +1,45 @@
+# Copyright 2023 ForgeFlow S.L. (https://www.forgeflow.com)
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+
+from odoo import api, models
+
+MOVE_TYPE_MAP = {
+    "out_invoice": ["sale", "all"],
+    "out_refund": ["sale", "all"],
+    "in_invoice": ["purchase", "all"],
+    "in_refund": ["purchase", "all"],
+}
+
+
+class AccountMove(models.Model):
+    _inherit = "account.move"
+
+    @api.model
+    def _get_payment_term_applicable_on_type_mapping(self):
+        """
+        Returns a dictionary with the different account.move types, having as the value
+        all the applicable on options for which the account.payment.term will not
+        trigger an error. (applicable_on field on model account.payment.term).
+
+        :return: dictionary with the account.move types and the applicable on as the value
+        """
+        all_applicable_on = [
+            x[0] for x in self.env["account.payment.term"]._selection_applicable_on()
+        ]
+        return {
+            **MOVE_TYPE_MAP,
+            **{
+                type[0]: all_applicable_on
+                for type in self._fields["type"].selection
+                if type[0] not in MOVE_TYPE_MAP.keys()
+            },
+        }
+
+    @api.constrains("invoice_payment_term_id")
+    def _check_invoice_payment_term_id(self):
+        applicable_on_type_mapping = self._get_payment_term_applicable_on_type_mapping()
+        moves = self.filtered(lambda move: move.invoice_payment_term_id)
+        for move in moves:
+            applicable_on = applicable_on_type_mapping.get(move.type)
+            move_pt = move.invoice_payment_term_id
+            move_pt.check_not_applicable(applicable_on, record=move)

--- a/account_payment_term_restriction/models/account_payment_term.py
+++ b/account_payment_term_restriction/models/account_payment_term.py
@@ -1,0 +1,70 @@
+# Copyright 2023 ForgeFlow S.L. (https://www.forgeflow.com)
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
+
+
+class AccountPaymentTerm(models.Model):
+    _inherit = "account.payment.term"
+
+    applicable_on = fields.Selection(
+        selection="_selection_applicable_on",
+        string="Applicable On",
+        default=lambda self: self._get_default_applicable_on(),
+    )
+
+    @api.model
+    def _selection_applicable_on(self):
+        return [
+            ("sale", "Sales"),
+            ("purchase", "Purchases"),
+            ("all", "All"),
+        ]
+
+    @api.model
+    def _get_default_applicable_on(self):
+        return "all"
+
+    @api.model
+    def get_sale_applicable_on(self):
+        return ["sale", "all"]
+
+    @api.model
+    def get_purchase_applicable_on(self):
+        return ["purchase", "all"]
+
+    def _skip_check_not_applicable(self, record):
+        """
+        :return: bool: returns True if the restriction checks can be skipped either if
+        the context to skip the checks is passed or the pre-checks are not fulfilled,
+        False otherwise.
+        """
+        if self.env.context.get("skip_payment_term_restriction", False):
+            return True
+        skip = not bool(
+            self
+            and len(self) == 1
+            and self.applicable_on
+            and record
+            and isinstance(record, models.BaseModel)
+            and ("partner_id" in record._fields or record._name == "res.partner")
+        )
+        return skip
+
+    def check_not_applicable(self, applicable_on, record):
+        """
+        :return: bool: returns True if all checks are passed correctly, False if the
+        pre-check for the values used in the validation fails.
+
+        Raises a ValidationError if the Payment Term doesn't comply with the checks.
+        """
+        if self._skip_check_not_applicable(record):
+            return False
+        if applicable_on and self.applicable_on not in applicable_on:
+            sale = "sale" in applicable_on
+            msg = "You can only assign Payment Terms of type %s or All." % (
+                "Sales" if sale else "Purchases"
+            )
+            raise ValidationError(_(msg))
+        return True

--- a/account_payment_term_restriction/readme/CONFIGURE.rst
+++ b/account_payment_term_restriction/readme/CONFIGURE.rst
@@ -1,0 +1,8 @@
+To be able to configure the restriction on Payment Terms you first need to go to the
+menu Invoicing > Configuration > Management > Payment Terms.
+
+Once there, opening any Payment Term or creating a new one, there'll be an option where
+you can set Sales, Purchase or All. The value will be the restriction applied to
+Journal Entries.
+
+You can pass the `skip_payment_term_restriction` context to avoid the checks.

--- a/account_payment_term_restriction/readme/CONTRIBUTORS.rst
+++ b/account_payment_term_restriction/readme/CONTRIBUTORS.rst
@@ -1,0 +1,3 @@
+* ForgeFlow S.L. <https://www.forgeflow.com>
+
+    * Guillem Casassas <guillem.casassas@forgeflow.com>

--- a/account_payment_term_restriction/readme/DESCRIPTION.rst
+++ b/account_payment_term_restriction/readme/DESCRIPTION.rst
@@ -1,0 +1,8 @@
+This module adds the possibility to restrict the use of Payment Terms in Journal
+Entries.
+
+By setting a restriction value on the Payment Term, the restrictions applied will be:
+
+  * Sales: This Payment Term can only be set on Invoices / Credit Notes.
+  * Purchase: This Payment Term can only be set on Bills / Refunds.
+  * All: It can be applied to both Sales and Purchase types.

--- a/account_payment_term_restriction/tests/__init__.py
+++ b/account_payment_term_restriction/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_account_payment_term_restriction

--- a/account_payment_term_restriction/tests/test_account_payment_term_restriction.py
+++ b/account_payment_term_restriction/tests/test_account_payment_term_restriction.py
@@ -1,0 +1,91 @@
+# Copyright 2023 ForgeFlow S.L. (https://www.forgeflow.com)
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+
+import odoo.tests.common as common
+from odoo import exceptions
+
+
+@common.at_install(False)
+@common.post_install(True)
+class TestAccountPaymentTermRestriction(common.SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+
+        cls.account_payment_term_model = cls.env["account.payment.term"]
+        cls.acocunt_move_model = cls.env["account.move"]
+        cls.res_partner_model = cls.env["res.partner"]
+
+        # Create three different Payment Terms
+        cls.sale_payment_term = cls._create_payment_term("Sale Payment Term", "sale")
+        cls.purchase_payment_term = cls._create_payment_term(
+            "Purchase Payment Term", "purchase"
+        )
+        cls.all_payment_term = cls._create_payment_term("All Payment Term", "all")
+
+        # Instances
+        cls.partner_id = cls.env.user.partner_id
+        cls.currency_id = cls.env.ref("base.EUR")
+
+    @classmethod
+    def _create_payment_term(cls, name, applicable_on=False):
+        return cls.account_payment_term_model.create(
+            {"name": name, "applicable_on": applicable_on}
+        )
+
+    @classmethod
+    def _create_account_move(cls, name, move_type):
+        return cls.acocunt_move_model.create(
+            {"name": name, "type": move_type, "currency_id": cls.currency_id.id}
+        )
+
+    def test_01_assign_payment_term_to_account_move(self):
+        """
+        Test to check the different scenarios when assigning payment terms to Journal Entries
+        """
+        # Invoice
+        invoice = self._create_account_move("Test Invoice", "out_invoice")
+        invoice.write({"invoice_payment_term_id": self.sale_payment_term.id})
+        invoice.write({"invoice_payment_term_id": self.all_payment_term.id})
+        with self.assertRaises(exceptions.ValidationError):
+            invoice.write({"invoice_payment_term_id": self.purchase_payment_term.id})
+
+        # Credit Note
+        credit_note = self._create_account_move("Test Credit Note", "out_refund")
+        credit_note.write({"invoice_payment_term_id": self.sale_payment_term.id})
+        credit_note.write({"invoice_payment_term_id": self.all_payment_term.id})
+        with self.assertRaises(exceptions.ValidationError):
+            credit_note.write(
+                {"invoice_payment_term_id": self.purchase_payment_term.id}
+            )
+
+        # Bill
+        bill = self._create_account_move("Test Bill", "in_invoice")
+        bill.write({"invoice_payment_term_id": self.purchase_payment_term.id})
+        bill.write({"invoice_payment_term_id": self.all_payment_term.id})
+        with self.assertRaises(exceptions.ValidationError):
+            bill.write({"invoice_payment_term_id": self.sale_payment_term.id})
+
+        # Refund
+        refund = self._create_account_move("Test Refund", "in_refund")
+        refund.write({"invoice_payment_term_id": self.purchase_payment_term.id})
+        refund.write({"invoice_payment_term_id": self.all_payment_term.id})
+        with self.assertRaises(exceptions.ValidationError):
+            refund.write({"invoice_payment_term_id": self.sale_payment_term.id})
+
+        # Miscellaneous
+        entry = self._create_account_move("Test Entry", "entry")
+        entry.write({"invoice_payment_term_id": self.all_payment_term.id})
+        entry.write({"invoice_payment_term_id": self.sale_payment_term.id})
+        entry.write({"invoice_payment_term_id": self.purchase_payment_term.id})
+
+    def test_02_skip_check_if_context(self):
+        """
+        For Journal Entry, check that you can skip the check if the context is passed
+        """
+        invoice = self._create_account_move("Test Invoice", "out_invoice").with_context(
+            skip_payment_term_restriction=True
+        )
+        # Check that it works for each case where it'd fail without the context
+        invoice.write({"invoice_payment_term_id": self.purchase_payment_term.id})

--- a/account_payment_term_restriction/views/account_payment_term.xml
+++ b/account_payment_term_restriction/views/account_payment_term.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+    Copyright 2023 ForgeFlow S.L. (https://www.forgeflow.com)
+    License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+-->
+<odoo>
+    <record id="view_payment_term_tree" model="ir.ui.view">
+        <field
+            name="name"
+        >account.payment.term.tree - account_payment_term_restriction</field>
+        <field name="model">account.payment.term</field>
+        <field name="inherit_id" ref="account.view_payment_term_tree" />
+        <field name="arch" type="xml">
+            <field name="company_id" position="after">
+                <field name="applicable_on" optional="hide" />
+            </field>
+        </field>
+    </record>
+    <record id="view_payment_term_form" model="ir.ui.view">
+        <field
+            name="name"
+        >account.payment.term.form - account_payment_term_restriction</field>
+        <field name="model">account.payment.term</field>
+        <field name="inherit_id" ref="account.view_payment_term_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//group/group" position="after">
+                <group name="restriction" string="Restriction">
+                    <field name="applicable_on" widget="radio" />
+                </group>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/account_payment_term_restriction_purchase/__init__.py
+++ b/account_payment_term_restriction_purchase/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/account_payment_term_restriction_purchase/__manifest__.py
+++ b/account_payment_term_restriction_purchase/__manifest__.py
@@ -1,0 +1,12 @@
+# Copyright 2023 ForgeFlow S.L. (https://www.forgeflow.com)
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+{
+    "name": "Payment Term Restriction Purchase",
+    "version": "13.0.1.0.0",
+    "category": "Accounting & Finance",
+    "summary": "Restricts the usage of Payment Terms on POs",
+    "author": "ForgeFlow, Odoo Community Association (OCA)",
+    "website": "https://github.com/OCA/account-payment",
+    "license": "LGPL-3",
+    "depends": ["account_payment_term_restriction", "purchase"],
+}

--- a/account_payment_term_restriction_purchase/models/__init__.py
+++ b/account_payment_term_restriction_purchase/models/__init__.py
@@ -1,0 +1,2 @@
+from . import purchase_order
+from . import res_partner

--- a/account_payment_term_restriction_purchase/models/purchase_order.py
+++ b/account_payment_term_restriction_purchase/models/purchase_order.py
@@ -1,0 +1,17 @@
+# Copyright 2023 ForgeFlow S.L. (https://www.forgeflow.com)
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+
+from odoo import api, models
+
+
+class PurchaseOrder(models.Model):
+    _inherit = "purchase.order"
+
+    @api.constrains("payment_term_id")
+    def _check_payment_term_id(self):
+        purchase_applicable_on = self.env[
+            "account.payment.term"
+        ].get_purchase_applicable_on()
+        for purchase in self:
+            purchase_pt = purchase.payment_term_id
+            purchase_pt.check_not_applicable(purchase_applicable_on, record=purchase)

--- a/account_payment_term_restriction_purchase/models/res_partner.py
+++ b/account_payment_term_restriction_purchase/models/res_partner.py
@@ -1,0 +1,17 @@
+# Copyright 2023 ForgeFlow S.L. (https://www.forgeflow.com)
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+
+from odoo import api, models
+
+
+class ResPartner(models.Model):
+    _inherit = "res.partner"
+
+    @api.constrains("property_supplier_payment_term_id")
+    def _check_property_supplier_payment_term_id(self):
+        purchase_applicable_on = self.env[
+            "account.payment.term"
+        ].get_purchase_applicable_on()
+        for partner in self:
+            partner_pt = partner.property_supplier_payment_term_id
+            partner_pt.check_not_applicable(purchase_applicable_on, record=partner)

--- a/account_payment_term_restriction_purchase/readme/CONTRIBUTORS.rst
+++ b/account_payment_term_restriction_purchase/readme/CONTRIBUTORS.rst
@@ -1,0 +1,3 @@
+* ForgeFlow S.L. <https://www.forgeflow.com>
+
+    * Guillem Casassas <guillem.casassas@forgeflow.com>

--- a/account_payment_term_restriction_purchase/readme/DESCRIPTION.rst
+++ b/account_payment_term_restriction_purchase/readme/DESCRIPTION.rst
@@ -1,0 +1,4 @@
+This module adds the possibility to restrict the use of Payment Terms in Purchases.
+
+Only Payment Terms having the applicable on value as Purchases or All can be applied in
+Purchase Orders.

--- a/account_payment_term_restriction_purchase/tests/__init__.py
+++ b/account_payment_term_restriction_purchase/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_account_payment_term_restriction_purchase

--- a/account_payment_term_restriction_purchase/tests/test_account_payment_term_restriction_purchase.py
+++ b/account_payment_term_restriction_purchase/tests/test_account_payment_term_restriction_purchase.py
@@ -1,0 +1,60 @@
+# Copyright 2023 ForgeFlow S.L. (https://www.forgeflow.com)
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+
+import odoo.tests.common as common
+from odoo import exceptions
+
+from odoo.addons.account_payment_term_restriction.tests import (
+    test_account_payment_term_restriction,
+)
+
+
+@common.at_install(False)
+@common.post_install(True)
+class TestAccountPaymentTermRestrictionPurchase(
+    test_account_payment_term_restriction.TestAccountPaymentTermRestriction
+):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+
+        cls.purchase_order_model = cls.env["purchase.order"]
+
+    @classmethod
+    def _create_po(cls, name):
+        return cls.purchase_order_model.create(
+            {"name": name, "partner_id": cls.partner_id.id}
+        )
+
+    def test_01_assign_payment_term_to_purchase_order(self):
+        """
+        Test to check the different scenarios when assigning payment terms to Purchase Order
+        """
+        po = self._create_po("Test PO")
+        po.write({"payment_term_id": self.purchase_payment_term.id})
+        po.write({"payment_term_id": self.all_payment_term.id})
+        with self.assertRaises(exceptions.ValidationError):
+            po.write({"payment_term_id": self.sale_payment_term.id})
+
+    def test_02_assign_payment_term_to_partner(self):
+        """
+        Test to check the different scenarios when assigning supplier payment terms to
+        Partner
+        """
+        partner = self.partner_id
+        partner.write({"property_payment_term_id": self.all_payment_term.id})
+        partner.write({"property_payment_term_id": self.sale_payment_term.id})
+        with self.assertRaises(exceptions.ValidationError):
+            partner.write({"property_payment_term_id": self.purchase_payment_term.id})
+
+    def test_03_skip_check_if_context(self):
+        """
+        For a PO and a Partner check that you can skip the check if the context is
+        passed
+        """
+        po = self._create_po("Test PO").with_context(skip_payment_term_restriction=True)
+        partner = self.partner_id.with_context(skip_payment_term_restriction=True)
+        # Check that it works for each case where it'd fail without the context
+        po.write({"payment_term_id": self.sale_payment_term.id})
+        partner.write({"property_supplier_payment_term_id": self.sale_payment_term.id})

--- a/account_payment_term_restriction_sale/__init__.py
+++ b/account_payment_term_restriction_sale/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/account_payment_term_restriction_sale/__manifest__.py
+++ b/account_payment_term_restriction_sale/__manifest__.py
@@ -1,0 +1,12 @@
+# Copyright 2023 ForgeFlow S.L. (https://www.forgeflow.com)
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+{
+    "name": "Payment Term Restriction Sale",
+    "version": "13.0.1.0.0",
+    "category": "Accounting & Finance",
+    "summary": "Restricts the usage of Payment Terms on SOs",
+    "author": "ForgeFlow, Odoo Community Association (OCA)",
+    "website": "https://github.com/OCA/account-payment",
+    "license": "LGPL-3",
+    "depends": ["account_payment_term_restriction", "sale"],
+}

--- a/account_payment_term_restriction_sale/models/__init__.py
+++ b/account_payment_term_restriction_sale/models/__init__.py
@@ -1,0 +1,2 @@
+from . import res_partner
+from . import sale_order

--- a/account_payment_term_restriction_sale/models/res_partner.py
+++ b/account_payment_term_restriction_sale/models/res_partner.py
@@ -1,0 +1,15 @@
+# Copyright 2023 ForgeFlow S.L. (https://www.forgeflow.com)
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+
+from odoo import api, models
+
+
+class ResPartner(models.Model):
+    _inherit = "res.partner"
+
+    @api.constrains("property_payment_term_id")
+    def _check_property_payment_term_id(self):
+        sale_applicable_on = self.env["account.payment.term"].get_sale_applicable_on()
+        for partner in self:
+            partner_pt = partner.property_payment_term_id
+            partner_pt.check_not_applicable(sale_applicable_on, record=partner)

--- a/account_payment_term_restriction_sale/models/sale_order.py
+++ b/account_payment_term_restriction_sale/models/sale_order.py
@@ -1,0 +1,15 @@
+# Copyright 2023 ForgeFlow S.L. (https://www.forgeflow.com)
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+
+from odoo import api, models
+
+
+class SaleOrder(models.Model):
+    _inherit = "sale.order"
+
+    @api.constrains("payment_term_id")
+    def _check_payment_term_id(self):
+        sale_applicable_on = self.env["account.payment.term"].get_sale_applicable_on()
+        for sale in self:
+            sale_pt = sale.payment_term_id
+            sale_pt.check_not_applicable(sale_applicable_on, record=sale)

--- a/account_payment_term_restriction_sale/readme/CONTRIBUTORS.rst
+++ b/account_payment_term_restriction_sale/readme/CONTRIBUTORS.rst
@@ -1,0 +1,3 @@
+* ForgeFlow S.L. <https://www.forgeflow.com>
+
+    * Guillem Casassas <guillem.casassas@forgeflow.com>

--- a/account_payment_term_restriction_sale/readme/DESCRIPTION.rst
+++ b/account_payment_term_restriction_sale/readme/DESCRIPTION.rst
@@ -1,0 +1,4 @@
+This module adds the possibility to restrict the use of Payment Terms in Sales.
+
+Only Payment Terms having the applicable on value as Sales or All can be applied in
+Sale Orders.

--- a/account_payment_term_restriction_sale/tests/__init__.py
+++ b/account_payment_term_restriction_sale/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_account_payment_term_restriction_sale

--- a/account_payment_term_restriction_sale/tests/test_account_payment_term_restriction_sale.py
+++ b/account_payment_term_restriction_sale/tests/test_account_payment_term_restriction_sale.py
@@ -1,0 +1,60 @@
+# Copyright 2023 ForgeFlow S.L. (https://www.forgeflow.com)
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+
+import odoo.tests.common as common
+from odoo import exceptions
+
+from odoo.addons.account_payment_term_restriction.tests import (
+    test_account_payment_term_restriction,
+)
+
+
+@common.at_install(False)
+@common.post_install(True)
+class TestAccountPaymentTermRestrictionSale(
+    test_account_payment_term_restriction.TestAccountPaymentTermRestriction
+):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+
+        cls.res_partner_model = cls.env["res.partner"]
+        cls.sale_order_model = cls.env["sale.order"]
+
+    @classmethod
+    def _create_so(cls, name):
+        return cls.sale_order_model.create(
+            {"name": name, "partner_id": cls.partner_id.id}
+        )
+
+    def test_01_assign_payment_term_to_sale_order(self):
+        """
+        Test to check the different scenarios when assigning payment terms to Sales Order
+        """
+        so = self._create_so("Test SO")
+        so.write({"payment_term_id": self.sale_payment_term.id})
+        so.write({"payment_term_id": self.all_payment_term.id})
+        with self.assertRaises(exceptions.ValidationError):
+            so.write({"payment_term_id": self.purchase_payment_term.id})
+
+    def test_02_assign_payment_term_to_partner(self):
+        """
+        Test to check the different scenarios when assigning payment terms to Partner
+        """
+        partner = self.partner_id
+        partner.write({"property_payment_term_id": self.all_payment_term.id})
+        partner.write({"property_payment_term_id": self.sale_payment_term.id})
+        with self.assertRaises(exceptions.ValidationError):
+            partner.write({"property_payment_term_id": self.purchase_payment_term.id})
+
+    def test_03_skip_check_if_context(self):
+        """
+        For a SO, PO, Partner and Journal Entry, check that you can skip the check
+        if the context is passed
+        """
+        so = self._create_so("Test SO").with_context(skip_payment_term_restriction=True)
+        partner = self.partner_id.with_context(skip_payment_term_restriction=True)
+        # Check that it works for each case where it'd fail without the context
+        so.write({"payment_term_id": self.purchase_payment_term.id})
+        partner.write({"property_payment_term_id": self.purchase_payment_term.id})

--- a/setup/account_payment_term_restriction/odoo/addons/account_payment_term_restriction
+++ b/setup/account_payment_term_restriction/odoo/addons/account_payment_term_restriction
@@ -1,0 +1,1 @@
+../../../../account_payment_term_restriction

--- a/setup/account_payment_term_restriction/setup.py
+++ b/setup/account_payment_term_restriction/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)

--- a/setup/account_payment_term_restriction_purchase/odoo/addons/account_payment_term_restriction_purchase
+++ b/setup/account_payment_term_restriction_purchase/odoo/addons/account_payment_term_restriction_purchase
@@ -1,0 +1,1 @@
+../../../../account_payment_term_restriction_purchase

--- a/setup/account_payment_term_restriction_purchase/setup.py
+++ b/setup/account_payment_term_restriction_purchase/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)

--- a/setup/account_payment_term_restriction_sale/odoo/addons/account_payment_term_restriction_sale
+++ b/setup/account_payment_term_restriction_sale/odoo/addons/account_payment_term_restriction_sale
@@ -1,0 +1,1 @@
+../../../../account_payment_term_restriction_sale

--- a/setup/account_payment_term_restriction_sale/setup.py
+++ b/setup/account_payment_term_restriction_sale/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
This module adds the possibility to restrict the usage of payment terms in SOs, POs, partners and journal entries.

cc @ForgeFlow