### PR TITLE
[14.0][ADD] partner_restrict_payment_acquirer

### DIFF
--- a/partner_restrict_payment_acquirer/__init__.py
+++ b/partner_restrict_payment_acquirer/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/partner_restrict_payment_acquirer/__manifest__.py
+++ b/partner_restrict_payment_acquirer/__manifest__.py
@@ -1,0 +1,16 @@
+{
+    "name": "Partner Restrict Payment Acquirer",
+    "summary": "Partner Restrict Payment Acquirer",
+    "author": "Cetmix, Odoo Community Association (OCA)",
+    "version": "14.0.1.0.0",
+    "category": "Accounting",
+    "website": "https://github.com/OCA/account-payment",
+    "maintainers": ["geomer198", "CetmixGitDrone"],
+    "depends": ["sale"],
+    "data": [
+        "views/payment_templates.xml",
+        "views/res_partner_views.xml",
+    ],
+    "license": "AGPL-3",
+    "installable": True,
+}

--- a/partner_restrict_payment_acquirer/models/__init__.py
+++ b/partner_restrict_payment_acquirer/models/__init__.py
@@ -1,0 +1,2 @@
+from . import payment_acquirer
+from . import res_partner

--- a/partner_restrict_payment_acquirer/models/payment_acquirer.py
+++ b/partner_restrict_payment_acquirer/models/payment_acquirer.py
@@ -1,0 +1,30 @@
+from odoo import api, models
+
+
+class PaymentAcquirer(models.Model):
+    _inherit = "payment.acquirer"
+
+    @api.model
+    def get_allowed_acquirers(self, acquirers, invoice_id=None, order_id=None):
+        """
+        Get allowed acquirers by the customer
+        :param list acquirers: list of acquirers
+        :param int invoice_id: invoice id
+        :param int order_id: quotation id
+        :return list: List of allowed acquirers
+        """
+        if order_id:
+            model = "sale.order"
+            rec_id = order_id
+        elif invoice_id:
+            model = "account.move"
+            rec_id = invoice_id
+        else:
+            return acquirers
+        record = self.env[model].sudo().browse(rec_id)
+        customer_acquirers = record.partner_id.allowed_acquirer_ids
+        return (
+            list(set(acquirers) & set(customer_acquirers))
+            if customer_acquirers
+            else acquirers
+        )

--- a/partner_restrict_payment_acquirer/models/res_partner.py
+++ b/partner_restrict_payment_acquirer/models/res_partner.py
@@ -1,0 +1,14 @@
+from odoo import fields, models
+
+
+class ResPartner(models.Model):
+    _inherit = "res.partner"
+
+    allowed_acquirer_ids = fields.Many2many(
+        comodel_name="payment.acquirer",
+        relation="partner_acquirer_allowed_rel",
+        column1="partner_id",
+        column2="acquirer_id",
+        string="Allowed Acquirers",
+        domain=[("state", "in", ["enabled", "test"])],
+    )

--- a/partner_restrict_payment_acquirer/readme/DESCRIPTION.rst
+++ b/partner_restrict_payment_acquirer/readme/DESCRIPTION.rst
@@ -1,0 +1,1 @@
+This module allows to restrict payment acquirers for partner. Only selected acquirers will be available for online payment in portal.

--- a/partner_restrict_payment_acquirer/readme/ROADMAP.rst
+++ b/partner_restrict_payment_acquirer/readme/ROADMAP.rst
@@ -1,0 +1,1 @@
+Would be reasonable to create an extension of this module for E-Commerce. Eg "partner_restrict_payment_acquirer_website"

--- a/partner_restrict_payment_acquirer/readme/USAGE.rst
+++ b/partner_restrict_payment_acquirer/readme/USAGE.rst
@@ -1,0 +1,4 @@
+Open partner form and go to "Sales & Purchases" tab. Add payment acquirers in "Allowed Acquirers" filed.
+When partner opens invoice in portal only allowed acquirers will be available for payment.
+
+Note: leaving this field empty will remove any restrictions and allow to select any acquirer.

--- a/partner_restrict_payment_acquirer/tests/__init__.py
+++ b/partner_restrict_payment_acquirer/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_payment_acquirer

--- a/partner_restrict_payment_acquirer/tests/test_payment_acquirer.py
+++ b/partner_restrict_payment_acquirer/tests/test_payment_acquirer.py
@@ -1,0 +1,81 @@
+from odoo.tests import TransactionCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestPaymentAcquirer(TransactionCase):
+    def setUp(self) -> None:
+        super(TestPaymentAcquirer, self).setUp()
+        self.invoice_test_1 = self.env.ref("l10n_generic_coa.demo_invoice_followup")
+        self.order_test_1 = self.env.ref("sale.sale_order_7")
+        self.res_partner_deco = self.env.ref("base.res_partner_2")
+        self.res_partner_gemini = self.env.ref("base.res_partner_3")
+        self.acquirers_list = list(
+            self.env["payment.acquirer"].search([("state", "in", ["enabled", "test"])])
+        )
+        self.wire_transfer = self.env.ref("payment.payment_acquirer_transfer")
+
+    def test_get_allowed_acquirers(self):
+        payment_acquirer_obj = self.env["payment.acquirer"]
+        acquirers = payment_acquirer_obj.get_allowed_acquirers(self.acquirers_list)
+        self.assertListEqual(
+            acquirers, self.acquirers_list, msg="Acquirers lists must be same"
+        )
+
+    def test_get_allowed_acquirers_order(self):
+        """This test covers acquirer selection based on partner settings for sale order"""
+        payment_acquirer_obj = self.env["payment.acquirer"]
+
+        acquirers = payment_acquirer_obj.get_allowed_acquirers(
+            self.acquirers_list, order_id=self.order_test_1.id
+        )
+        self.assertListEqual(
+            acquirers, self.acquirers_list, msg="Acquirers lists must be same"
+        )
+        customer_acquirers = self.res_partner_gemini.allowed_acquirer_ids
+        self.assertFalse(customer_acquirers, msg="Acquirers must be empty")
+
+        self.res_partner_gemini.write(
+            {"allowed_acquirer_ids": [(4, self.wire_transfer.id)]}
+        )
+        customer_acquirers = self.res_partner_gemini.allowed_acquirer_ids
+        self.assertEqual(
+            customer_acquirers,
+            self.wire_transfer,
+            msg="Customer acquirers must be contain 'Wire Transfer'",
+        )
+        acquirers = payment_acquirer_obj.get_allowed_acquirers(
+            self.acquirers_list, order_id=self.order_test_1.id
+        )
+        self.assertEqual(
+            acquirers, [self.wire_transfer], msg="Acquirers must be the same"
+        )
+
+    def test_get_allowed_acquirers_invoice(self):
+        """This test covers acquirer selection based on partner settings for invoice"""
+        payment_acquirer_obj = self.env["payment.acquirer"]
+
+        acquirers = payment_acquirer_obj.get_allowed_acquirers(
+            self.acquirers_list, invoice_id=self.invoice_test_1.id
+        )
+        self.assertListEqual(
+            acquirers, self.acquirers_list, msg="Acquirers lists must be same"
+        )
+
+        customer_acquirers = self.res_partner_deco.allowed_acquirer_ids
+        self.assertFalse(customer_acquirers, msg="Acquirers must be empty")
+
+        self.res_partner_deco.write(
+            {"allowed_acquirer_ids": [(4, self.wire_transfer.id)]}
+        )
+        customer_acquirers = self.res_partner_deco.allowed_acquirer_ids
+        self.assertEqual(
+            customer_acquirers,
+            self.wire_transfer,
+            msg="Customer acquirers must be contain 'Wire Transfer'",
+        )
+        acquirers = payment_acquirer_obj.get_allowed_acquirers(
+            self.acquirers_list, invoice_id=self.invoice_test_1.id
+        )
+        self.assertEqual(
+            acquirers, [self.wire_transfer], msg="Acquirers must be the same"
+        )

--- a/partner_restrict_payment_acquirer/views/payment_templates.xml
+++ b/partner_restrict_payment_acquirer/views/payment_templates.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <template inherit_id="payment.payment_tokens_list" id="payment_tokens_list">
+        <form position="before">
+            <t t-if="sale_order and not order_id">
+                <t t-set="order_id" t-value="sale_order.id" />
+            </t>
+            <t t-if="invoice and not invoice_id">
+                <t t-set="invoice_id" t-value="invoice.id" />
+            </t>
+            <t
+                t-set="acquirers"
+                t-value="env['payment.acquirer'].get_allowed_acquirers(acquirers, invoice_id, order_id)"
+            />
+        </form>
+    </template>
+</odoo>

--- a/partner_restrict_payment_acquirer/views/res_partner_views.xml
+++ b/partner_restrict_payment_acquirer/views/res_partner_views.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+
+    <record id="view_partner_form" model="ir.ui.view">
+        <field name="name">res.partner.form.view</field>
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="base.view_partner_form" />
+        <field name="arch" type="xml">
+            <group name="sale" position="inside">
+                <field
+                    name="allowed_acquirer_ids"
+                    widget="many2many_tags"
+                    groups="account.group_account_invoice"
+                />
+            </group>
+        </field>
+    </record>
+
+</odoo>

--- a/setup/partner_restrict_payment_acquirer/odoo/addons/partner_restrict_payment_acquirer
+++ b/setup/partner_restrict_payment_acquirer/odoo/addons/partner_restrict_payment_acquirer
@@ -1,0 +1,1 @@
+../../../../partner_restrict_payment_acquirer

--- a/setup/partner_restrict_payment_acquirer/setup.py
+++ b/setup/partner_restrict_payment_acquirer/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
This module allows to restrict payment acquirers for partner. Only selected acquirers will be available on invoice payment page.