### PR TITLE
[14.0][IMP] account_payment_return: Return to same account used in payment receipt

### DIFF
--- a/account_payment_return/models/payment_return.py
+++ b/account_payment_return/models/payment_return.py
@@ -177,7 +177,7 @@ class PaymentReturn(models.Model):
             "name": move.ref,
             "debit": 0.0,
             "credit": total_amount,
-            "account_id": self.journal_id.payment_credit_account_id.id,
+            "account_id": self.journal_id.payment_debit_account_id.id,
             "move_id": move.id,
             "journal_id": move.journal_id.id,
         }


### PR DESCRIPTION
If payment account used is payment_debit_account_id this account should be used in the payment return

@Tecnativa

ping @omar7r @ao-landoo 