### PR TITLE
[14.0][FIX] account_cash_discount_payment

### DIFF
--- a/account_cash_discount_payment/__manifest__.py
+++ b/account_cash_discount_payment/__manifest__.py
@@ -8,7 +8,7 @@
     "website": "https://github.com/OCA/account-payment",
     "license": "AGPL-3",
     "category": "Accounting",
-    "depends": ["account_cash_discount_base", "account_payment_order"],
+    "depends": ["account_cash_discount_base", "account_payment_order_grouped_output"],
     "data": [
         "views/account_move_line.xml",
         "views/account_payment_line.xml",


### PR DESCRIPTION
Fixed dependencies in account_cash_discount_payment module  as it caused issues in account_cash_discount_write_off tests in PRs: https://github.com/OCA/account-payment/pull/589, https://github.com/OCA/account-payment/pull/431, https://github.com/OCA/account-payment/pull/578, https://github.com/OCA/account-payment/pull/605.