### PR TITLE
[14.0][IMP] account_due_list: date_maturity asc order in tree view

### DIFF
--- a/account_due_list/views/payment_view.xml
+++ b/account_due_list/views/payment_view.xml
@@ -15,6 +15,7 @@
                 decoration-danger="reconciled==False and date_maturity&lt;current_date and parent_state=='posted'"
                 create="false"
                 delete="false"
+                default_order="date_maturity"
             >
                 <field name="date" readonly="1" optional="hide" />
                 <field name="invoice_date" readonly="1" optional="show" />


### PR DESCRIPTION
A small change for usability, placing the due date in an ascending way in the tree view can help the user to better position themselves in what has the most urgent payment/receipt right from the start.