### PR TITLE
[14.0][FIX] account_payment_multi_deduction - allow edit move multi write-off

### DIFF
--- a/account_payment_multi_deduction/models/account_payment.py
+++ b/account_payment_multi_deduction/models/account_payment.py
@@ -1,10 +1,13 @@
 # Copyright 2020 Ecosoft Co., Ltd (http://ecosoft.co.th/)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html)
-from odoo import models
+
+from odoo import fields, models
 
 
 class AccountPayment(models.Model):
     _inherit = "account.payment"
+
+    is_multi_deduction = fields.Boolean()
 
     def _prepare_move_line_default_vals(self, write_off_line_vals=None):
         """Split amount to multi payment deduction
@@ -39,3 +42,12 @@ class AccountPayment(models.Model):
                 write_off_line_vals
             )
         return line_vals_list
+
+    def _synchronize_from_moves(self, changed_fields):
+        ctx = self._context.copy()
+        if all(rec.is_multi_deduction for rec in self):
+            ctx["skip_account_move_synchronization"] = True
+        return super(
+            AccountPayment,
+            self.with_context(**ctx),
+        )._synchronize_from_moves(changed_fields)

--- a/account_payment_multi_deduction/wizard/account_payment_register.py
+++ b/account_payment_multi_deduction/wizard/account_payment_register.py
@@ -67,6 +67,7 @@ class AccountPaymentRegister(models.TransientModel):
                 self._prepare_deduct_move_line(deduct)
                 for deduct in self.deduction_ids.filtered(lambda l: not l.open)
             ]
+            payment_vals["is_multi_deduction"] = True
         return payment_vals
 
     def _prepare_deduct_move_line(self, deduct):


### PR DESCRIPTION
This PR is fixed case can't edit move line multi write-off.
In core odoo not allow multi account in  write-off but this module add multi write-off and skip check when register payment.

![Selection_009](https://user-images.githubusercontent.com/20896369/224911189-d3907a16-65ed-4b99-b72a-92ac3b290bd3.png)
