### PR TITLE
[15.0][FIX] account_payment_return_import_iso20022: Restore compatibility with pre-payment orders

### DIFF
--- a/account_payment_return_import_iso20022/models/payment_return.py
+++ b/account_payment_return_import_iso20022/models/payment_return.py
@@ -16,6 +16,9 @@ class PaymentReturnLine(models.Model):
             move_id = int(line.reference) if line.reference.isdigit() else -1
             payments = self.env["account.payment"].search(
                 [
+                    "|",
+                    # Compatibility with old approach - To be removed on v16
+                    ("old_bank_payment_line_name", "=", line.reference),
                     ("move_id", "=", move_id),
                     ("payment_order_id", "!=", False),
                 ],


### PR DESCRIPTION
This legacy compatibility shouldn't be removed yet, as if you migrate from <v14, you don't have the new references.

@Tecnativa TT42966