### PR TITLE
[15.0][FIX] account_payment_return_import_iso20022: Method _compute_amount is not called…

### DIFF
--- a/account_payment_return_import_iso20022/models/payment_return.py
+++ b/account_payment_return_import_iso20022/models/payment_return.py
@@ -11,7 +11,6 @@ class PaymentReturnLine(models.Model):
 
     def _find_match(self):
         """Include in the matches the lines coming from payment orders."""
-        matched = self.env["payment.return.line"]
         for line in self.filtered(lambda x: not x.move_line_ids and x.reference):
             move_id = int(line.reference) if line.reference.isdigit() else -1
             payments = self.env["account.payment"].search(
@@ -25,10 +24,9 @@ class PaymentReturnLine(models.Model):
             )
             if payments:
                 line.partner_id = payments[0].partner_id
-                matched += line
                 for payment in payments:
                     line.move_line_ids |= payment.move_id.line_ids.filtered(
                         lambda x: x.account_id == payment.destination_account_id
                         and x.partner_id == payment.partner_id
                     )
-        return super(PaymentReturnLine, self - matched)._find_match()
+        return super()._find_match()


### PR DESCRIPTION
… because records are removed in super()

In the original method all the records are expected:
https://github.com/OCA/account-payment/blob/ad9ee855fed524c0d7bf216d9a289aa2fb5ec272/account_payment_return/models/payment_return.py#L377-L392

@Tecnativa TT43373