### PR TITLE
[14.0][FIX] account_payment_paired_internal_transfer: Issue 626

### DIFF
--- a/account_payment_paired_internal_transfer/models/account_payment.py
+++ b/account_payment_paired_internal_transfer/models/account_payment.py
@@ -42,6 +42,7 @@ class AccountPayment(models.Model):
                     and "inbound"
                     or "outbound",
                     "move_id": None,
+                    "date": payment.date,
                     "ref": payment.ref,
                     "paired_internal_transfer_payment_id": payment.id,
                 }


### PR DESCRIPTION
Fix to BUG [Date of account move does not respect the Date entered](https://github.com/OCA/account-payment/issues/626)

- Adjusted to make the payment copy obtain the same date instead of taking the current date.

cc @marcelsavegnago @douglascstd 