### PR TITLE
[14.0][FIX] account_payment_paired_internal_transfer: use same date of payment

### DIFF
--- a/account_payment_paired_internal_transfer/models/account_payment.py
+++ b/account_payment_paired_internal_transfer/models/account_payment.py
@@ -44,6 +44,7 @@ class AccountPayment(models.Model):
                     "move_id": None,
                     "ref": payment.ref,
                     "paired_internal_transfer_payment_id": payment.id,
+                    "date": payment.date,
                 }
             )
             paired_payment.move_id._post(soft=False)


### PR DESCRIPTION
This PR fixes an error when creating the internal transfer, the date defined of the other move is the creation date instead of the transfer date