### PR TITLE
[16.0][FIX] account_payment_return: add is_exchange

### DIFF
--- a/account_payment_return/models/account_move.py
+++ b/account_payment_return/models/account_move.py
@@ -50,6 +50,7 @@ class AccountMove(models.Model):
             "payment_method_name": payment_method_name,
             "ref": "{} ({})".format(line_id.move_id.name, line_id.ref),
             "returned": is_return,
+            "is_exchange": False,
         }
 
     def _compute_payments_widget_reconciled_info(self):


### PR DESCRIPTION
When we have a invoice with returned_payment the invoice report gives an error because is_exchange don't exist. 

We make this fix to avoid that.