### PR TITLE
[14.0][FIX] account_due_list_payment: same group in tree and form

### DIFF
--- a/account_due_list_payment/views/account_move_line.xml
+++ b/account_due_list_payment/views/account_move_line.xml
@@ -40,7 +40,7 @@
                         name="action_register_payment"
                         type="object"
                         string="Register Payment"
-                        groups="account.group_account_user"
+                        groups="account.group_account_invoice"
                     />
                 </header>
             </field>


### PR DESCRIPTION
In tree and form view de group necessary to see the buttom are different.