### PR TITLE
[15.0][FIX] account_check_printing_report_base: fix test to use correct payment method line in account payment

### DIFF
--- a/account_check_printing_report_base/tests/test_check_printing_report.py
+++ b/account_check_printing_report_base/tests/test_check_printing_report.py
@@ -20,6 +20,7 @@ class TestAccountCheckPrintingReportBase(TransactionCase):
         self.account_invoice_model = self.env["account.move"]
         self.journal_model = self.env["account.journal"]
         self.payment_method_model = self.env["account.payment.method"]
+        self.payment_method_line_model = self.env["account.payment.method.line"]
         self.account_account_model = self.env["account.account"]
         self.payment_model = self.env["account.payment"]
         self.report = self.env[
@@ -64,9 +65,13 @@ class TestAccountCheckPrintingReportBase(TransactionCase):
                 "type": "bank",
                 "code": "bank",
                 "check_manual_sequencing": True,
-                # "outbound_payment_method_ids": [
-                #     (4, self.payment_method_check.id, None)
-                # ],
+            }
+        )
+        self.payment_method_line_check = self.payment_method_line_model.create(
+            {
+                "name": "Check",
+                "payment_method_id": self.payment_method_check.id,
+                "journal_id": self.bank_journal.id,
             }
         )
         self.acc_payable = self._create_account(
@@ -86,7 +91,7 @@ class TestAccountCheckPrintingReportBase(TransactionCase):
             {
                 "date": time.strftime("%Y") + "-07-15",
                 "journal_id": self.bank_journal.id,
-                "payment_method_line_id": self.payment_method_check.id,
+                "payment_method_line_id": self.payment_method_line_check.id,
             }
         )
         register_payments.action_post()


### PR DESCRIPTION
The solution of the tests of the modules account_payment_promissory_note and account_check_printing_report_base is added, since doing separate PR's the tests of one failed in the other respectively.

cc @Tecnativa TT47880

@pedrobaeza @CarlosRoca13  please review