### PR TITLE
[14.0] [FIX] account_payment_term_discount: Difference in rounding

### DIFF
--- a/account_payment_term_discount/models/account_move.py
+++ b/account_payment_term_discount/models/account_move.py
@@ -3,7 +3,6 @@
 from dateutil.relativedelta import relativedelta
 
 from odoo import api, fields, models
-from odoo.tools import float_round
 
 
 class AccountMove(models.Model):
@@ -44,10 +43,7 @@ class AccountMove(models.Model):
                     )
                 )
                 if discount_information[0] > 0.0:
-                    rounding = invoice.currency_id.rounding
-                    invoice.discount_amt = abs(
-                        float_round(discount_information[0], rounding)
-                    )
+                    invoice.discount_amt = abs(discount_information[0])
                     # If discount taken make disc amt to 0 as disc is no more valid
                     if invoice.discount_taken != 0:
                         invoice.discount_amt = 0

--- a/account_payment_term_discount/models/account_move.py
+++ b/account_payment_term_discount/models/account_move.py
@@ -3,6 +3,7 @@
 from dateutil.relativedelta import relativedelta
 
 from odoo import api, fields, models
+from odoo.tools import float_round
 
 
 class AccountMove(models.Model):
@@ -43,7 +44,10 @@ class AccountMove(models.Model):
                     )
                 )
                 if discount_information[0] > 0.0:
-                    invoice.discount_amt = abs(round(discount_information[0], 2))
+                    rounding = invoice.currency_id.rounding
+                    invoice.discount_amt = abs(
+                        float_round(discount_information[0], rounding)
+                    )
                     # If discount taken make disc amt to 0 as disc is no more valid
                     if invoice.discount_taken != 0:
                         invoice.discount_amt = 0

--- a/account_payment_term_discount/models/account_payment_term.py
+++ b/account_payment_term_discount/models/account_payment_term.py
@@ -39,7 +39,7 @@ class AccountPaymentTerm(models.Model):
                 )
 
                 if line.discount and payment_date <= till_discount_date:
-                    payment_discount = round((amount * line.discount) / 100.0, 2)
+                    payment_discount = (amount * line.discount) / 100.0
                     if invoice.move_type in ("out_invoice", "in_refund"):
                         discount_account_id = line.discount_expense_account_id.id
                     else:
@@ -99,4 +99,4 @@ class AccountPaymentTermLine(models.Model):
     def OnchangeDiscount(self):
         if not self.discount:
             return {}
-        self.value_amount = round(1 - (self.discount / 100.0), 2)
+        self.value_amount = 1 - (self.discount / 100.0)

--- a/account_payment_term_discount/models/account_payment_term.py
+++ b/account_payment_term_discount/models/account_payment_term.py
@@ -87,11 +87,15 @@ class AccountPaymentTermLine(models.Model):
     discount_income_account_id = fields.Many2one(
         "account.account",
         string="Discount on Purchases Account",
+        ondelete="restrict",
+        company_dependent=True,
         help="This account will be used to post the discount on purchases.",
     )
     discount_expense_account_id = fields.Many2one(
         "account.account",
         string="Discount on Sales Account",
+        ondelete="restrict",
+        company_dependent=True,
         help="This account will be used to post the discount on sales.",
     )
 

--- a/account_payment_term_discount/wizard/account_payment_register.py
+++ b/account_payment_term_discount/wizard/account_payment_register.py
@@ -4,7 +4,6 @@ from dateutil.relativedelta import relativedelta
 
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
-from odoo.tools import float_round
 
 
 class AccountPaymentRegister(models.TransientModel):
@@ -45,9 +44,7 @@ class AccountPaymentRegister(models.TransientModel):
                 )
                 payment_date = fields.Date.from_string(self.payment_date)
                 discount_amt = self.invoice_id.discount_amt
-
-                rounding = self.invoice_id.currency_id.rounding
-                payment_difference = float_round(self.payment_difference, rounding)
+                payment_difference = self.payment_difference
                 self.payment_difference = 0.0
 
                 if payment_date <= till_discount_date:
@@ -105,12 +102,9 @@ class AccountPaymentRegister(models.TransientModel):
         res = super().action_create_payments()
         for payment in self:
             if payment.payment_difference_handling == "reconcile":
-                rounding = payment.invoice_id.currency_id.rounding
                 payment.invoice_id.write(
                     {
-                        "discount_taken": abs(
-                            float_round(payment.payment_difference, rounding)
-                        ),
+                        "discount_taken": abs(payment.payment_difference),
                         "discount_amt": 0,
                     }
                 )

--- a/account_payment_term_discount/wizard/account_payment_register.py
+++ b/account_payment_term_discount/wizard/account_payment_register.py
@@ -4,6 +4,7 @@ from dateutil.relativedelta import relativedelta
 
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
+from odoo.tools import float_round
 
 
 class AccountPaymentRegister(models.TransientModel):
@@ -45,7 +46,8 @@ class AccountPaymentRegister(models.TransientModel):
                 payment_date = fields.Date.from_string(self.payment_date)
                 discount_amt = self.invoice_id.discount_amt
 
-                payment_difference = self.payment_difference
+                rounding = self.invoice_id.currency_id.rounding
+                payment_difference = float_round(self.payment_difference, rounding)
                 self.payment_difference = 0.0
 
                 if payment_date <= till_discount_date:
@@ -103,9 +105,12 @@ class AccountPaymentRegister(models.TransientModel):
         res = super().action_create_payments()
         for payment in self:
             if payment.payment_difference_handling == "reconcile":
+                rounding = payment.invoice_id.currency_id.rounding
                 payment.invoice_id.write(
                     {
-                        "discount_taken": abs(payment.payment_difference),
+                        "discount_taken": abs(
+                            float_round(payment.payment_difference, rounding)
+                        ),
                         "discount_amt": 0,
                     }
                 )


### PR DESCRIPTION
 In the context of this module's application, we encountered a specific issue involving:

* Discount Amount: 229.95
* Payment Difference: 229.95000000000002

Although there is no rounding in _compute_payment_difference() of account module and this module performs rounding in _compute_discount_amt(). 

This discrepancy in rounding can lead to different comparison results. 

This commit aims to rectify the inconsistency in rounding between these two fields, ensuring accurate comparisons.