### PR TITLE
[17.0] dotfiles update needs manual intervention

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Do NOT update manually; changes here will be overwritten by Copier
-_commit: v1.19
+_commit: v1.21.1
 _src_path: gh:oca/oca-addons-repo-template
 additional_ruff_rules: []
 ci: GitHub

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Stale PRs and issues policy
-        uses: actions/stale@v4
+        uses: actions/stale@v9
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           # General settings.
@@ -48,7 +48,7 @@ jobs:
       # * Issues that are pending more information
       # * Except Issues marked as "no stale"
       - name: Needs more information stale issues policy
-        uses: actions/stale@v4
+        uses: actions/stale@v9
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           ascending: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,7 +63,9 @@ jobs:
         run: oca_init_test_database
       - name: Run tests
         run: oca_run_tests
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
       - name: Update .pot files
         run: oca_export_and_push_pot https://x-access-token:${{ secrets.GIT_PUSH_TOKEN }}@github.com/${{ github.repository }}
         if: ${{ matrix.makepot == 'true' && github.event_name == 'push' && github.repository_owner == 'OCA' }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,6 +16,8 @@ exclude: |
   readme/.*\.(rst|md)$|
   # Ignore build and dist directories in addons
   /build/|/dist/|
+  # Ignore test files in addons
+  /tests/samples/.*|
   # You don't usually want a bot to modify your legal texts
   (LICENSE.*|COPYING.*)
 default_language_version:
@@ -41,7 +43,7 @@ repos:
     hooks:
       - id: whool-init
   - repo: https://github.com/oca/maintainer-tools
-    rev: f71041f22b8cd68cf7c77b73a14ca8d8cd190a60
+    rev: 9a170331575a265c092ee6b24b845ec508e8ef75
     hooks:
       # update the NOT INSTALLABLE ADDONS section above
       - id: oca-update-pre-commit-excluded-addons
@@ -110,7 +112,7 @@ repos:
         args: [--fix, --exit-non-zero-on-fix]
       - id: ruff-format
   - repo: https://github.com/OCA/pylint-odoo
-    rev: v8.0.19
+    rev: v9.0.4
     hooks:
       - id: pylint_odoo
         name: pylint with optional checks

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -6,6 +6,7 @@ fix = true
 extend-select = [
     "B",
     "C90",
+    "E501",  # line too long (default 88)
     "I",  # isort
     "UP",  # pyupgrade
 ]

--- a/account_payment_term_extension/tests/test_payment_term.py
+++ b/account_payment_term_extension/tests/test_payment_term.py
@@ -151,7 +151,8 @@ class TestAccountPaymentTerm(TransactionCase):
                 self.assertEqual(
                     payment_term_date,
                     "2015-05-31",
-                    "Error in the _compute_terms of payment terms with months after invoice month",
+                    "Error in the _compute_terms of payment terms with months after "
+                    "invoice month",
                 )
 
     def test_postpone_holiday(self):


### PR DESCRIPTION
Dear maintainer,

After updating the dotfiles, `pre-commit run -a`
fails in a manner that cannot be resolved automatically.

Can you please have a look, fix and merge?

Thanks,
