### PR TITLE
[15.0][FIX] account_payment_term_partner_holiday: don't split moves on post

### DIFF
--- a/account_payment_term_partner_holiday/models/account_move.py
+++ b/account_payment_term_partner_holiday/models/account_move.py
@@ -35,9 +35,7 @@ class AccountMove(models.Model):
                 self.invoice_date_due = new_invoice_date_due
 
     def action_post(self):
-        """Inject a context for getting the partner when computing payment term."""
-        for move in self:
-            super(
-                AccountMove, self.with_context(move_partner_id=move.partner_id.id)
-            ).action_post()
-        return False
+        """Ensure that the payment terms are up to date when we confirm the move"""
+        for move in self.filtered("invoice_date_due"):
+            move._recompute_payment_terms_lines()
+        return super().action_post()

--- a/account_payment_term_partner_holiday/static/description/index.html
+++ b/account_payment_term_partner_holiday/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>

--- a/account_payment_term_partner_holiday/tests/test_partner_holiday.py
+++ b/account_payment_term_partner_holiday/tests/test_partner_holiday.py
@@ -333,6 +333,39 @@ class TestPartnerHoliday(common.TransactionCase):
             invoice_form.invoice_date_due, fields.Date.from_string("2021-06-14")
         )
 
+    def test_partner_2_invoice_change_due_date_on_confirm(self):
+        """A partner's holidays could have changed since we created the invoice. Let's
+        ensure that the due dates are correct when we post it"""
+        invoice_form = self._set_invoice_form(self.partner_2.id, "2021-06-13")
+        invoice_form.invoice_payment_term_id = self.payment_term_immediate
+        self.assertEqual(
+            invoice_form.invoice_date_due, fields.Date.from_string("2021-06-13")
+        )
+        invoice = invoice_form.save()
+        self.partner_2.write(
+            {
+                "holiday_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "day_from": "1",
+                            "month_from": "06",
+                            "day_to": "31",
+                            "month_to": "06",
+                        },
+                    ),
+                ]
+            }
+        )
+        self.assertEqual(
+            invoice.invoice_date_due, fields.Date.from_string("2021-06-13")
+        )
+        invoice.action_post()
+        self.assertEqual(
+            invoice.invoice_date_due, fields.Date.from_string("2021-07-01")
+        )
+
     def test_partner_1_get_valid_due_date(self):
         self.assertEqual(
             self.partner_1._get_valid_due_date(fields.Date.from_string("2021-01-01")),


### PR DESCRIPTION
The technique of splitting the move on action_post was causing unexpected errors when we were posting multiple moves at once.

If we just want to ensure to recompute the payment terms, we can do so triggering just triggering them.

cc @Tecntiva TT49375

please check @victoralmau @pedrobaeza 