### PR TITLE
[IMP] account_payment_batch_process: prefer grouping payments per invoice

### DIFF
--- a/account_payment_batch_process/wizard/account_payment_register.xml
+++ b/account_payment_batch_process/wizard/account_payment_register.xml
@@ -19,12 +19,15 @@
                     >Customer Invoices Being Paid</h3>
                 </div>
                 <group invisible="not context.get('batch', False)">
+                    <group>
+                    <field name="group_by_partner" />
                     <button
-                        name="auto_fill_payments"
-                        string="Auto-Fill Pay Amount"
-                        type="object"
-                        class="oe_highlight"
-                    />
+                            name="auto_fill_payments"
+                            string="Auto-Fill Pay Amount"
+                            type="object"
+                            class="oe_highlight"
+                        />
+                    </group>
                 </group>
                 <notebook invisible="not context.get('batch', False)">
                     <page name="invoice_payments" string="Invoice Payments">


### PR DESCRIPTION
PR will add the chances to allow group payments by `invoice` (default), other than `partner`. 

Grouping by invoice will allow to reconcile partial payments for multiple invoice per partner, i.e.:

Partner: 

invoice 1:  total amount 100,00, partial payment 30,00
invoice 2: total amount 200,00, partial payment 150,00.

Grouping by invoice will be possible to have both invoice partially reconciled and set as partially paid, while grouping by partner only invoice 1 will be partially reconciled.
