### PR TITLE
[16.0][FIX] account_payment_batch_process: allow original domain of payment method line

### DIFF
--- a/account_payment_batch_process/wizard/account_payment_register.xml
+++ b/account_payment_batch_process/wizard/account_payment_register.xml
@@ -85,11 +85,6 @@
             <xpath expr="//field[@name='amount']" position="attributes">
                 <attribute name="invisible">context.get('batch', False)</attribute>
             </xpath>
-            <xpath expr="//field[@name='payment_method_line_id']" position="attributes">
-                <attribute
-                    name="domain"
-                >[('payment_type', '=', payment_type)]</attribute>
-            </xpath>
             <xpath expr="//field[@name='communication']" position="after">
                 <field
                     name="cheque_amount"


### PR DESCRIPTION
As the existing domain is good enough to limit the choices of payment methods, and the previous approach would be confusing because it would show payment method lines associated with all the journals.