### PR TITLE
[16.0][IMP] account_payment_term_discount: add migration script

### DIFF
--- a/account_payment_term_discount/migrations/16.0.1.0.0/post-migration.py
+++ b/account_payment_term_discount/migrations/16.0.1.0.0/post-migration.py
@@ -1,0 +1,13 @@
+# Copyright 2024 ForgeFlow, S.L.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo.tools.sql import column_exists
+
+
+def migrate(cr, version):
+    if not column_exists(cr, "account_payment_term_line", "discount"):
+        return
+    cr.execute(
+        """UPDATE account_payment_term_line
+        SET discount_percentage = discount
+        WHERE discount IS NOT NULL and discount_percentage IS NULL"""
+    )


### PR DESCRIPTION
the field 'discount' in the payment term line was defined in this module, but as of 16.0 the field 'discount_percentage' is applied already.

With this script we are copying the value from the previous column to the new one.

cc @ChrisOForgeFlow @alexpforgeflow