### PR TITLE
[16.0][FIX] account_cash_invoice: Do not create account for test

### DIFF
--- a/account_cash_invoice/tests/test_pay_invoice.py
+++ b/account_cash_invoice/tests/test_pay_invoice.py
@@ -17,15 +17,6 @@ class TestSessionPayInvoice(BaseCommon):
         cls.company = cls.env.ref("base.main_company")
         partner = cls.env.ref("base.partner_demo")
         cls.product = cls.env.ref("product.product_delivery_02")
-        account = cls.env["account.account"].create(
-            {
-                "code": "449000",
-                "company_id": cls.company.id,
-                "name": "Test",
-                "account_type": "income",
-                "reconcile": True,
-            }
-        )
         cls.invoice_out = cls.AccountMove.create(
             {
                 "company_id": cls.company.id,
@@ -38,7 +29,6 @@ class TestSessionPayInvoice(BaseCommon):
                         False,
                         {
                             "product_id": cls.product.id,
-                            "account_id": account.id,
                             "name": "Producto de prueba",
                             "quantity": 1.0,
                             "price_unit": 100.0,
@@ -64,7 +54,6 @@ class TestSessionPayInvoice(BaseCommon):
                         {
                             "product_id": cls.product.id,
                             "name": "Producto de prueba",
-                            "account_id": account.id,
                             "quantity": 1.0,
                             "price_unit": 100.0,
                             "tax_ids": [],


### PR DESCRIPTION
- This account code conflicts with other chart accounts(other modules), so we are removing it.

https://github.com/odoo/odoo/blob/16.0/addons/l10n_hr_euro/data/account.account.template.csv#L325
https://github.com/odoo/odoo/blob/16.0/addons/l10n_fr/data/account.account.template.csv#L368


Log
`psycopg2.errors.UniqueViolation: duplicate key value violates unique constraint "account_account_code_company_uniq"﻿[﻿2077﻿]DETAIL: Key (code, company_id)=(449000, 1) already exists.`

@tecnativa TT50198
