### PR TITLE
[16.0][FIX] account_cash_invoice: Filter only lines not reconciled

### DIFF
--- a/account_cash_invoice/wizard/cash_pay_invoice.py
+++ b/account_cash_invoice/wizard/cash_pay_invoice.py
@@ -102,6 +102,7 @@ class CashPayInvoice(models.TransientModel):
         ).filtered(
             lambda l: l.account_id.account_type
             in ("asset_receivable", "liability_payable")
+            and not l.reconciled
         )
         lines_to_reconcile.reconcile()
 


### PR DESCRIPTION
With other modules, it raises the error: "You are trying to reconcile some entries that are already reconciled."

@tecnativa TT50198