### PR TITLE
[16.0][FIX] account_payment_return: Fix line_ids display on form view

### DIFF
--- a/account_payment_return/views/payment_return_view.xml
+++ b/account_payment_return/views/payment_return_view.xml
@@ -58,13 +58,11 @@
                             <field name="move_id" readonly="True" />
                         </group>
                     </group>
-                    <notebook colspan="4">
+                    <notebook>
                         <page string="Lines">
                             <field
                                 name="line_ids"
-                                colspan="4"
                                 nolabel="1"
-                                widget="one2many_list"
                                 context="{'default_date': date}"
                             >
                                 <tree editable="top">


### PR DESCRIPTION
Fix on `line_ids` field in form view. This is because when adding lines, the disposition of the table is wrong:
![image](https://github.com/user-attachments/assets/d039f78d-67b8-41ca-924b-f4a8e1f8d6c5)

With these changes, the disposition is correct:
![image](https://github.com/user-attachments/assets/e36cacc8-6362-4dca-a517-dbab1d299e94)
