### PR TITLE
[17.0][FIX] account_payment_return: Fix line_ids display on form view

### DIFF
--- a/account_payment_return/views/payment_return_view.xml
+++ b/account_payment_return/views/payment_return_view.xml
@@ -66,13 +66,11 @@
                             <field name="move_id" readonly="True" />
                         </group>
                     </group>
-                    <notebook colspan="4">
+                    <notebook>
                         <page string="Lines">
                             <field
                                 name="line_ids"
-                                colspan="4"
                                 nolabel="1"
-                                widget="one2many_list"
                                 context="{'default_date': date}"
                                 readonly="state in ['cancelled', 'done']"
                             >


### PR DESCRIPTION
Port changes from [!749](https://github.com/OCA/account-payment/pull/749) to 17.0