### PR TITLE
[15.0][FIX] account_payment_return: don't copy some fields

### DIFF
--- a/account_payment_return/models/account_move.py
+++ b/account_payment_return/models/account_move.py
@@ -12,6 +12,7 @@ class AccountMove(models.Model):
     returned_payment = fields.Boolean(
         string="Payment returned",
         help="Invoice has been included on a payment that has been returned later.",
+        copy=False,
     )
 
     def check_payment_return(self):

--- a/account_payment_return/models/payment_return.py
+++ b/account_payment_return/models/payment_return.py
@@ -50,6 +50,7 @@ class PaymentReturn(models.Model):
         comodel_name="account.move",
         string="Reference to the created journal entry",
         states={"done": [("readonly", True)], "cancelled": [("readonly", True)]},
+        copy=False,
     )
     total_amount = fields.Float(
         compute="_compute_total_amount",


### PR DESCRIPTION
If an invoice with the returned_payment field set is duplicated, the new invoice will incorrectly have this field activated. This fix prevents that from happening. same case for field move_id on payment.return

Partial backport of https://github.com/OCA/account-payment/pull/752 according comment https://github.com/OCA/account-payment/pull/752#pullrequestreview-2199342339

@Tecnativa TT49281

@pedrobaeza @carolinafernandez-tecnativa  could you review please