### PR TITLE
[16.0][FIX] account_payment_term_extension: Add cash_rounding parameter to _compute_terms() to prevent error

### DIFF
--- a/account_payment_term_extension/README.rst
+++ b/account_payment_term_extension/README.rst
@@ -71,6 +71,11 @@ Select any payment term and set a date in invoice.
 
 You must see the due date based on this payment term.
 
+Known issues / Roadmap
+======================
+
+This module is not compatible with cash rounding
+
 Bug Tracker
 ===========
 

--- a/account_payment_term_extension/models/account_payment_term.py
+++ b/account_payment_term_extension/models/account_payment_term.py
@@ -226,8 +226,11 @@ class AccountPaymentTerm(models.Model):
         sign,
         untaxed_amount,
         untaxed_amount_currency,
+        cash_rounding=None,
     ):
         """Complete overwrite of compute method for adding extra options."""
+        if cash_rounding:
+            raise UserError(_("This module is not compatible with cash rounding"))
         # FIXME: Find an inheritable way of doing this
         self.ensure_one()
         company_currency = company.currency_id

--- a/account_payment_term_extension/readme/ROADMAP.rst
+++ b/account_payment_term_extension/readme/ROADMAP.rst
@@ -1,0 +1,1 @@
+This module is not compatible with cash rounding

--- a/account_payment_term_extension/static/description/index.html
+++ b/account_payment_term_extension/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
@@ -392,12 +391,13 @@ the due date of the first line</li>
 <ul class="simple">
 <li><a class="reference internal" href="#configuration" id="toc-entry-1">Configuration</a></li>
 <li><a class="reference internal" href="#usage" id="toc-entry-2">Usage</a></li>
-<li><a class="reference internal" href="#bug-tracker" id="toc-entry-3">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="toc-entry-4">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="toc-entry-5">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="toc-entry-6">Contributors</a></li>
-<li><a class="reference internal" href="#other-credits" id="toc-entry-7">Other credits</a></li>
-<li><a class="reference internal" href="#maintainers" id="toc-entry-8">Maintainers</a></li>
+<li><a class="reference internal" href="#known-issues-roadmap" id="toc-entry-3">Known issues / Roadmap</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="toc-entry-4">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="toc-entry-5">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="toc-entry-6">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="toc-entry-7">Contributors</a></li>
+<li><a class="reference internal" href="#other-credits" id="toc-entry-8">Other credits</a></li>
+<li><a class="reference internal" href="#maintainers" id="toc-entry-9">Maintainers</a></li>
 </ul>
 </li>
 </ul>
@@ -421,8 +421,12 @@ one.</p>
 <p>Select any payment term and set a date in invoice.</p>
 <p>You must see the due date based on this payment term.</p>
 </div>
+<div class="section" id="known-issues-roadmap">
+<h1><a class="toc-backref" href="#toc-entry-3">Known issues / Roadmap</a></h1>
+<p>This module is not compatible with cash rounding</p>
+</div>
 <div class="section" id="bug-tracker">
-<h1><a class="toc-backref" href="#toc-entry-3">Bug Tracker</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-4">Bug Tracker</a></h1>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/account-payment/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
@@ -430,9 +434,9 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h1><a class="toc-backref" href="#toc-entry-4">Credits</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-5">Credits</a></h1>
 <div class="section" id="authors">
-<h2><a class="toc-backref" href="#toc-entry-5">Authors</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-6">Authors</a></h2>
 <ul class="simple">
 <li>Camptocamp</li>
 <li>Tecnativa</li>
@@ -440,7 +444,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </ul>
 </div>
 <div class="section" id="contributors">
-<h2><a class="toc-backref" href="#toc-entry-6">Contributors</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-7">Contributors</a></h2>
 <ul class="simple">
 <li>Yannick Vaucher &lt;<a class="reference external" href="mailto:yannick.vaucher&#64;camptocamp.com">yannick.vaucher&#64;camptocamp.com</a>&gt;</li>
 <li>Alexis de Lattre &lt;<a class="reference external" href="mailto:alexis.delattre&#64;akretion.com">alexis.delattre&#64;akretion.com</a>&gt;</li>
@@ -467,11 +471,11 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </ul>
 </div>
 <div class="section" id="other-credits">
-<h2><a class="toc-backref" href="#toc-entry-7">Other credits</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-8">Other credits</a></h2>
 <p>The migration of this module from 15.0 to 16.0 was financially supported by Camptocamp</p>
 </div>
 <div class="section" id="maintainers">
-<h2><a class="toc-backref" href="#toc-entry-8">Maintainers</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-9">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
 <a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose


### PR DESCRIPTION
Add cash_rounding parameter to `_compute_terms()` to prevent error

Required since https://github.com/odoo/odoo/commit/84b03f7e90f49762612875ac61a8fb29920c585d

Please @pedrobaeza can you review it?

@Tecnativa