### PR TITLE
[17.0][IMP] account_payment_return: Shorten vertical used space

### DIFF
--- a/account_payment_return/views/account_move_views.xml
+++ b/account_payment_return/views/account_move_views.xml
@@ -9,7 +9,10 @@
         <field name="model">account.move</field>
         <field name="inherit_id" ref="account.view_move_form" />
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='invoice_date_due']//.." position="after">
+            <xpath
+                expr="//group[@id='header_left_group']/field[@name='invoice_vendor_bill_id']"
+                position="after"
+            >
                 <field name="returned_payment" readonly="True" />
             </xpath>
         </field>


### PR DESCRIPTION
Forward-port of #774 

Having the flag in the header right part, makes that part too crowded, while the left part is mostly empty, stealing vertical space to the really important things in the invoice: the lines, so we move the field in the view to the left part to compact the header.

![imagen](https://github.com/user-attachments/assets/152e81e1-e0b9-48d2-b4ce-d2436700cbf8)

@Tecnativa TT51768