### PR TITLE
[16.0][IMP] account_due_list: Avoid same priority than account.view_move_line_pivot

### DIFF
--- a/account_due_list/views/payment_view.xml
+++ b/account_due_list/views/payment_view.xml
@@ -202,6 +202,7 @@
     <record id="view_payments_pivot" model="ir.ui.view">
         <field name="name">account.move.line.pivot</field>
         <field name="model">account.move.line</field>
+        <field name="priority">999</field>
         <field name="arch" type="xml">
             <pivot string="Payments and due list">
                 <field name="journal_id" type="row" />


### PR DESCRIPTION
because account.action_account_moves_all have not defined view and it may be the case that the one in this module is used when it should not be.

@Tecnativa TT54575