### PR TITLE
[FIX] account_payment_term_extension: Display correct amounts in jour…

### DIFF
--- a/account_payment_term_extension/models/account_payment_term.py
+++ b/account_payment_term_extension/models/account_payment_term.py
@@ -183,12 +183,14 @@ class AccountPaymentTerm(models.Model):
             else:
                 # Percentage amounts
                 line_amount = line.compute_line_amount(
-                    total_amount, remaining_amount, precision_digits
-                )
-                company_line_amount = line.compute_line_amount(
                     total_amount_currency,
                     remaining_amount_currency,
                     company_precision_digits,
+                )
+                company_line_amount = line.compute_line_amount(
+                    total_amount,
+                    remaining_amount,
+                    precision_digits,
                 )
                 term_vals["company_amount"] = company_line_amount
                 term_vals["foreign_amount"] = line_amount


### PR DESCRIPTION

When we create an invoice with an amount of $500 with payment terms with multiple terms, the journal items (30, 60 y 90 days) are created with euros in the column that should be dollars.

![image](https://github.com/user-attachments/assets/79053949-9934-487f-bb31-f7150fb4120d)

Currently, this info is displayed as:

![image](https://github.com/user-attachments/assets/852ef39c-50c1-4a2f-b7a6-6b7b485a3705)


As you can see, it does not make sense for euros to be a higher amount than dollars.