### PR TITLE
[16.0][FIX] account_payment_term_extension: Post-install test + fallback to load CoA

### DIFF
--- a/account_payment_term_extension/tests/test_account_payment_term_multi_day.py
+++ b/account_payment_term_extension/tests/test_account_payment_term_multi_day.py
@@ -1,9 +1,10 @@
 import odoo.tests.common as common
 from odoo import fields
 from odoo.exceptions import ValidationError
-from odoo.tests.common import Form
+from odoo.tests.common import Form, tagged
 
 
+@tagged("post_install", "-at_install")
 class TestAccountPaymentTermMultiDay(common.TransactionCase):
     @classmethod
     def setUpClass(cls):
@@ -18,6 +19,15 @@ class TestAccountPaymentTermMultiDay(common.TransactionCase):
                 tracking_disable=True,
             )
         )
+        if not cls.env.company.chart_template_id:
+            # Load a CoA if there's none in current company
+            coa = cls.env.ref("l10n_generic_coa.configurable_chart_template", False)
+            if not coa:
+                # Load the first available CoA
+                coa = cls.env["account.chart.template"].search(
+                    [("visible", "=", True)], limit=1
+                )
+            coa.try_loading(company=cls.env.company, install_demo=False)
         cls.payment_term_model = cls.env["account.payment.term"]
         cls.invoice_model = cls.env["account.move"]
         cls.partner = cls.env["res.partner"].create({"name": "Test Partner"})

--- a/account_payment_term_extension/tests/test_payment_term.py
+++ b/account_payment_term_extension/tests/test_payment_term.py
@@ -3,9 +3,10 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 from odoo import fields
 from odoo.exceptions import ValidationError
-from odoo.tests.common import TransactionCase
+from odoo.tests.common import TransactionCase, tagged
 
 
+@tagged("post_install", "-at_install")
 class TestAccountPaymentTerm(TransactionCase):
     @classmethod
     def setUpClass(cls):
@@ -20,6 +21,15 @@ class TestAccountPaymentTerm(TransactionCase):
                 tracking_disable=True,
             )
         )
+        if not cls.env.company.chart_template_id:
+            # Load a CoA if there's none in current company
+            coa = cls.env.ref("l10n_generic_coa.configurable_chart_template", False)
+            if not coa:
+                # Load the first available CoA
+                coa = cls.env["account.chart.template"].search(
+                    [("visible", "=", True)], limit=1
+                )
+            coa.try_loading(company=cls.env.company, install_demo=False)
         cls.account_payment_term = cls.env["account.payment.term"]
         cls.currency = cls.env.company.currency_id
         cls.company = cls.env.company


### PR DESCRIPTION
Since odoo/odoo@d0342c8, the default existing company is not getting a CoA automatically, provoking than the current tests fail with error:

```
odoo.exceptions.UserError: No journal could be found in company My Company (San Francisco) for any of those types: purchase
```

provoked by the lack of a CoA installed.

Thus, we put tests post-install for being sure localization modules are installed, the same as AccountTestInvoicingCommon does, but we don't inherit from it, as it creates an overhead creating 2 new companies and loading their CoA, and some more stuff, while we don't need all of that.

Besides, if you don't have `l10n_generic_coa` installed, you can't use another CoA (like `l10n_es`) easily, so we put little code to select the first available CoA.

@Tecnativa