### PR TITLE
[16.0][FIX] account_payment_return: Post-install test + fallback to load CoA

### DIFF
--- a/account_payment_return/tests/test_payment_return.py
+++ b/account_payment_return/tests/test_payment_return.py
@@ -5,9 +5,11 @@
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
 from odoo.exceptions import UserError, ValidationError
+from odoo.tests import tagged
 from odoo.tests.common import Form, TransactionCase
 
 
+@tagged("post_install", "-at_install")
 class TestPaymentReturn(TransactionCase):
     @classmethod
     def setUpClass(cls):
@@ -22,6 +24,15 @@ class TestPaymentReturn(TransactionCase):
                 tracking_disable=True,
             )
         )
+        if not cls.env.company.chart_template_id:
+            # Load a CoA if there's none in current company
+            coa = cls.env.ref("l10n_generic_coa.configurable_chart_template", False)
+            if not coa:
+                # Load the first available CoA
+                coa = cls.env["account.chart.template"].search(
+                    [("visible", "=", True)], limit=1
+                )
+            coa.try_loading(company=cls.env.company, install_demo=False)
         cls.journal = cls.env["account.journal"].create(
             {"name": "Test Sales Journal", "code": "tVEN", "type": "sale"}
         )

--- a/account_payment_return_import/tests/test_import_base.py
+++ b/account_payment_return_import/tests/test_import_base.py
@@ -3,11 +3,13 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo.exceptions import UserError
+from odoo.tests import tagged
 from odoo.tests.common import Form
 
 from .test_import_file import TestPaymentReturnFile
 
 
+@tagged("post_install", "-at_install")
 class TestImportBase(TestPaymentReturnFile):
     """Run test to import payment return import."""
 
@@ -24,6 +26,15 @@ class TestImportBase(TestPaymentReturnFile):
                 tracking_disable=True,
             )
         )
+        if not cls.env.company.chart_template_id:
+            # Load a CoA if there's none in current company
+            coa = cls.env.ref("l10n_generic_coa.configurable_chart_template", False)
+            if not coa:
+                # Load the first available CoA
+                coa = cls.env["account.chart.template"].search(
+                    [("visible", "=", True)], limit=1
+                )
+            coa.try_loading(company=cls.env.company, install_demo=False)
         cls.company = cls.env.ref("base.main_company")
         cls.acc_number = "NL77ABNA0574908765"
         cls.acc_bank = cls.env["res.partner.bank"].create(

--- a/account_payment_return_import_iso20022/wizard/payment_return_import.py
+++ b/account_payment_return_import_iso20022/wizard/payment_return_import.py
@@ -31,9 +31,12 @@ class PaymentReturnImport(models.TransientModel):
     def _parse_file(self, data_file):
         data_file_elements = self._xml_split_file(data_file)
         payment_returns = []
-        for data_file_element in data_file_elements:
-            payment_returns.extend(self._parse_single_document(data_file_element))
-        return payment_returns
+        try:
+            for data_file_element in data_file_elements:
+                payment_returns.extend(self._parse_single_document(data_file_element))
+            return payment_returns
+        except Exception:
+            return super()._parse_file(data_file)
 
     @api.model
     def _parse_single_document(self, data_file):


### PR DESCRIPTION
Since odoo/odoo@d0342c8, the default existing company is not getting a CoA automatically, provoking than the current tests fail with the error:

`odoo.exceptions.UserError: No journal could be found in company My Company (San Francisco) for any of those types: sale`

Thus, we put tests post-install for being sure localization modules are installed, the same as AccountTestInvoicingCommon does, but we don't inherit from it, as it creates an overhead creating 2 new companies and loading their CoA and some more stuff, while we don't need all of that.

Besides, if you don't have `l10n_generic_coa` installed, you can't use another CoA (like `l10n_es`) easily, so we put little code to select the first available CoA.

@Tecnativa