### PR TITLE
[16.0][FIX] account_payment_term_extension: Define the appropriate value in some cases

### DIFF
--- a/account_payment_term_extension/models/account_payment_term.py
+++ b/account_payment_term_extension/models/account_payment_term.py
@@ -239,10 +239,10 @@ class AccountPaymentTerm(models.Model):
         untaxed_amount_left = untaxed_amount
         untaxed_amount_currency_left = untaxed_amount_currency
 
-        total_amount = remaining_amount = tax_amount + untaxed_amount
-        total_amount_currency = remaining_amount_currency = (
-            tax_amount_currency + untaxed_amount_currency
-        )
+        total_amount = tax_amount + untaxed_amount
+        total_amount_currency = tax_amount_currency + untaxed_amount_currency
+        foreign_rounding_amount = 0
+        company_rounding_amount = 0
         result = []
         precision_digits = currency.decimal_places
         company_precision_digits = company_currency.decimal_places
@@ -267,14 +267,10 @@ class AccountPaymentTerm(models.Model):
             }
 
             if line.value == "fixed":
-                line_amount = line.compute_line_amount(
-                    total_amount, remaining_amount, precision_digits
+                term_vals["company_amount"] = sign * company_currency.round(
+                    line.value_amount
                 )
-                company_line_amount = line.compute_line_amount(
-                    total_amount, remaining_amount, company_precision_digits
-                )
-                term_vals["company_amount"] = sign * company_line_amount
-                term_vals["foreign_amount"] = sign * line_amount
+                term_vals["foreign_amount"] = sign * currency.round(line.value_amount)
                 company_proportion = (
                     tax_amount / untaxed_amount if untaxed_amount else 1
                 )
@@ -295,16 +291,12 @@ class AccountPaymentTerm(models.Model):
                     term_vals["foreign_amount"] - line_tax_amount_currency
                 )
             elif line.value == "percent":
-                line_amount = line.compute_line_amount(
-                    total_amount, remaining_amount, precision_digits
+                term_vals["company_amount"] = company_currency.round(
+                    total_amount * (line.value_amount / 100.0)
                 )
-                company_line_amount = line.compute_line_amount(
-                    total_amount_currency,
-                    remaining_amount_currency,
-                    company_precision_digits,
+                term_vals["foreign_amount"] = currency.round(
+                    total_amount_currency * (line.value_amount / 100.0)
                 )
-                term_vals["company_amount"] = company_line_amount
-                term_vals["foreign_amount"] = line_amount
                 line_tax_amount = company_currency.round(
                     tax_amount * (line.value_amount / 100.0)
                 )
@@ -315,7 +307,6 @@ class AccountPaymentTerm(models.Model):
                 line_untaxed_amount_currency = (
                     term_vals["foreign_amount"] - line_tax_amount_currency
                 )
-
             elif line.value == "percent_amount_untaxed":
                 if company_currency != currency:
                     raise UserError(
@@ -353,15 +344,15 @@ class AccountPaymentTerm(models.Model):
             tax_amount_currency_left -= line_tax_amount_currency
             untaxed_amount_left -= line_untaxed_amount
             untaxed_amount_currency_left -= line_untaxed_amount_currency
-            remaining_amount = tax_amount_left + untaxed_amount_left
-            remaining_amount_currency = (
-                tax_amount_currency_left + untaxed_amount_currency_left
-            )
 
             if line.value == "balance":
-                term_vals["company_amount"] = tax_amount_left + untaxed_amount_left
+                term_vals["company_amount"] = (
+                    tax_amount_left + untaxed_amount_left - company_rounding_amount
+                )
                 term_vals["foreign_amount"] = (
-                    tax_amount_currency_left + untaxed_amount_currency_left
+                    tax_amount_currency_left
+                    + untaxed_amount_currency_left
+                    - foreign_rounding_amount
                 )
                 line_tax_amount = tax_amount_left
                 line_tax_amount_currency = tax_amount_currency_left

--- a/account_payment_term_extension/tests/test_account_payment_term_multi_day.py
+++ b/account_payment_term_extension/tests/test_account_payment_term_multi_day.py
@@ -320,8 +320,8 @@ class TestAccountPaymentTermMultiDay(common.TransactionCase):
             if line.date_maturity:
                 amounts.append(line.credit)
         self.assertEqual(
-            amounts[0],
-            500,
+            amounts,
+            [500.05, 500.05],
             "Incorrect round for invoice with payment days on "
             "15 and 20 then 5 and 10 (round)",
         )


### PR DESCRIPTION
Apply the same behavior as in `account` https://github.com/odoo/odoo/blob/733b1474e75b32c3a467b7c3f0a83c75467d4e50/addons/account/models/account_payment_term.py#L112.

Several problems are solved

```
ERROR prod odoo.addons.account_payment_term_extension.tests.test_account_payment_term_multi_day: FAIL: TestAccountPaymentTermMultiDay.test_invoice_multi_payment_term_round Traceback (most recent call last):
  File "/opt/odoo/auto/addons/account_payment_term_extension/tests/test_account_payment_term_multi_day.py", line 322, in test_invoice_multi_payment_term_round
    self.assertEqual(
AssertionError: 500.1 != 500 : Incorrect round for invoice with payment days on 15 and 20 then 5 and 10 (round)

```
If `account_invoice_report_due_list` was installed, an error was displayed in tests

```
ERROR prod odoo.addons.account_invoice_report_due_list.tests.test_invoice_report_due_list: FAIL: TestInvoiceReportDueList.test_due_list_currency_extra Traceback (most recent call last):
  File "/opt/odoo/auto/addons/account_invoice_report_due_list/tests/test_invoice_report_due_list.py", line 123, in test_due_list_currency_extra
    self.assertEqual(invoice2.get_multi_due_list()[0][2], 50.0)
AssertionError: 32.7 != 50.0
```

@Tecnativa