### PR TITLE
[16.0][FIX] account_payment_credit_card + account_cash_invoice: Post-install test + fallback to load CoA

### DIFF
--- a/account_cash_invoice/tests/test_pay_invoice.py
+++ b/account_cash_invoice/tests/test_pay_invoice.py
@@ -13,6 +13,15 @@ class TestSessionPayInvoice(BaseCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        if not cls.env.company.chart_template_id:
+            # Load a CoA if there's none in current company
+            coa = cls.env.ref("l10n_generic_coa.configurable_chart_template", False)
+            if not coa:
+                # Load the first available CoA
+                coa = cls.env["account.chart.template"].search(
+                    [("visible", "=", True)], limit=1
+                )
+            coa.try_loading(company=cls.env.company, install_demo=False)
         cls.AccountMove = cls.env["account.move"]
         cls.company = cls.env.ref("base.main_company")
         partner = cls.env.ref("base.partner_demo")

--- a/account_payment_credit_card/tests/test_payment_credit_card.py
+++ b/account_payment_credit_card/tests/test_payment_credit_card.py
@@ -4,30 +4,41 @@
 from datetime import datetime, timedelta
 
 # from odoo import fields
-from odoo.tests import common
+from odoo.tests import common, tagged
 from odoo.tools import DEFAULT_SERVER_DATE_FORMAT
 
 
+@tagged("-at_install", "post_install")
 class TestPaymentCreditCard(common.TransactionCase):
-    def setUp(self):
-        super(TestPaymentCreditCard, self).setUp()
-        self.account_invoice_obj = self.env["account.move"]
-        self.account_move_line_obj = self.env["account.move.line"]
-        self.account_account_obj = self.env["account.account"]
-        self.account_journal_obj = self.env["account.journal"]
-        self.partner_12 = self.env.ref("base.res_partner_12")
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        if not cls.env.company.chart_template_id:
+            # Load a CoA if there's none in current company
+            coa = cls.env.ref("l10n_generic_coa.configurable_chart_template", False)
+            if not coa:
+                # Load the first available CoA
+                coa = cls.env["account.chart.template"].search(
+                    [("visible", "=", True)], limit=1
+                )
+            coa.try_loading(company=cls.env.company, install_demo=False)
+        cls.account_invoice_obj = cls.env["account.move"]
+        cls.account_move_line_obj = cls.env["account.move.line"]
+        cls.account_account_obj = cls.env["account.account"]
+        cls.account_journal_obj = cls.env["account.journal"]
+        cls.partner_12 = cls.env.ref("base.res_partner_12")
 
-        self.journal_sale = self.account_journal_obj.create(
+        cls.journal_sale = cls.account_journal_obj.create(
             {"name": "sale_0", "code": "SALE0", "type": "sale", "credit_card": True}
         )
 
-        self.invoice_data_list = [
+        cls.invoice_data_list = [
             # Customer Invoice Data
             [
                 "out_invoice",
-                self.get_date(set_days=30),
-                self.partner_12.id,
-                self.journal_sale.id,
+                cls.get_date(set_days=30),
+                cls.partner_12.id,
+                cls.journal_sale.id,
             ],
         ]
 
@@ -56,7 +67,8 @@ class TestPaymentCreditCard(common.TransactionCase):
             invoice._post(soft=False)
             return invoice
 
-    def get_date(self, set_days):
+    @classmethod
+    def get_date(cls, set_days):
         return (datetime.now() - timedelta(days=-set_days)).strftime(
             DEFAULT_SERVER_DATE_FORMAT
         )


### PR DESCRIPTION
Since odoo/odoo@d0342c8, the default existing company is not getting a CoA automatically, provoking than the current tests fail with the error:

`odoo.exceptions.UserError: No journal could be found in company My Company (San Francisco) for any of those types: sale`

Thus, we put tests post-install for being sure localization modules are installed, the same as AccountTestInvoicingCommon does, but we don't inherit from it, as it creates an overhead creating 2 new companies and loading their CoA and some more stuff, while we don't need all of that.

Besides, if you don't have `l10n_generic_coa` installed, you can't use another CoA (like `l10n_es`) easily, so we put little code to select the first available CoA.

@Tecnativa