### PR TITLE
[18.0][FIX] account_payment_tier_validation: fix incorrect validation_status assertion in test

### DIFF
--- a/account_payment_tier_validation/tests/test_tier_validation.py
+++ b/account_payment_tier_validation/tests/test_tier_validation.py
@@ -70,8 +70,11 @@ class TestAccountPayment(BaseCommon):
                 "partner_id": self.customer.id,
             }
         )
-        reviews = payment.with_user(self.env.user.id).request_validation()
+        payment.invalidate_model()
         self.assertEqual(payment.validation_status, "no")
+        reviews = payment.with_user(self.env.user.id).request_validation()
+        payment.invalidate_model()
+        self.assertEqual(payment.validation_status, "waiting")
         self.assertTrue(reviews)
         record = payment.with_user(self.test_user_1.id)
         record.invalidate_model()


### PR DESCRIPTION
This PR fixes a unit test in `test_03_validation_account_payment` where the expected value of `validation_status` was incorrectly asserted as `"no"` immediately after calling `request_validation()`.

Due to the use of a `Many2oneReference` field (`res_id`) from [this commit](https://github.com/OCA/server-ux/commit/39de455d901e6cf80b6575e7b92b9e8716e8b741#diff-3b9d698849db56925e2d709a0a8977cec48b05074620a818313dd17b178c70ff) in the `tier.review` model, calling `request_validation()` immediately creates review records, which affects the computed value of `validation_status`.

However, the test incorrectly expected `validation_status` to still be `"no"` even after `request_validation()` was called — this is inconsistent with the model logic, where the creation of `"waiting"` reviews should update the status accordingly.

Additionally, the test behavior could vary depending on whether `validation_status` was accessed before or after calling `request_validation()`.


