### PR TITLE
[13.0][IMP] account_payment_term_restriction_purchase: test property_supplier_payment_term_id on partner instead of property_payment_term_id

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   pre-commit:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
               fi
           done
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container: ${{ matrix.container }}
     name: ${{ matrix.name }}
     strategy:

--- a/account_payment_term_restriction_purchase/tests/test_account_payment_term_restriction_purchase.py
+++ b/account_payment_term_restriction_purchase/tests/test_account_payment_term_restriction_purchase.py
@@ -43,10 +43,14 @@ class TestAccountPaymentTermRestrictionPurchase(
         Partner
         """
         partner = self.partner_id
-        partner.write({"property_payment_term_id": self.all_payment_term.id})
-        partner.write({"property_payment_term_id": self.sale_payment_term.id})
+        partner.write({"property_supplier_payment_term_id": self.all_payment_term.id})
+        partner.write(
+            {"property_supplier_payment_term_id": self.purchase_payment_term.id}
+        )
         with self.assertRaises(exceptions.ValidationError):
-            partner.write({"property_payment_term_id": self.purchase_payment_term.id})
+            partner.write(
+                {"property_supplier_payment_term_id": self.sale_payment_term.id}
+            )
 
     def test_03_skip_check_if_context(self):
         """


### PR DESCRIPTION
The test should check the field _property_supplier_payment_term_id_ of the partner
![image](https://github.com/user-attachments/assets/548fd627-3c1f-4266-abe9-caaaba8c5b2e)
