### PR TITLE
[16.0][FIX] account_payment_batch_process: set correct payment_type for customer invoices

### DIFF
--- a/account_payment_batch_process/wizard/account_payment_register.py
+++ b/account_payment_batch_process/wizard/account_payment_register.py
@@ -132,11 +132,8 @@ class AccountPaymentRegister(models.TransientModel):
                     "In order to pay multiple bills at once, they must use the same currency."
                 )
             )
-
+        is_customer = MAP_INVOICE_TYPE_PARTNER_TYPE[invoices[0].move_type] == "customer"
         if "batch" in context and context.get("batch"):
-            is_customer = (
-                MAP_INVOICE_TYPE_PARTNER_TYPE[invoices[0].move_type] == "customer"
-            )
             payment_lines = self.get_invoice_payments(invoices)
             res.update({"invoice_payments": payment_lines, "is_customer": is_customer})
         else:
@@ -164,7 +161,7 @@ class AccountPaymentRegister(models.TransientModel):
             {
                 "amount": abs(total_amount),
                 "currency_id": invoices[0].currency_id.id,
-                "payment_type": is_customer and "outbound" or "inbound",
+                "payment_type": "inbound" if is_customer else "outbound",
                 "partner_id": invoices[0].commercial_partner_id.id,
                 "partner_type": MAP_INVOICE_TYPE_PARTNER_TYPE[invoices[0].move_type],
                 "company_id": self.env.user.company_id.id,


### PR DESCRIPTION
The `payment_type` logic was changed in commit https://github.com/OCA/account-payment/commit/fe83e91, but the changes is wrong: it incorrectly sets the payment type of customer invoices to `'outbound'` (Send Money), whereas it should be `'inbound'` (Receive Money).

This logic assumes that a customer implies a payment direction of `'outbound'`, which contradicts Odoo's standard behavior. As shown in the Odoo core code https://github.com/odoo/odoo/blob/bf4e51980bf3bdf34b70b7c269f5da06983eb272/addons/account/models/account_payment.py#L207, customer invoices should have `payment_type = 'inbound'`.

