### PR TITLE
[16.0][FIX] account_payment_return: partial_reconcile_returned_ids is kept when invoice is duplicated

### DIFF
--- a/account_payment_return/models/account_move.py
+++ b/account_payment_return/models/account_move.py
@@ -63,6 +63,7 @@ class AccountMoveLine(models.Model):
         relation="account_partial_reconcile_account_move_line_rel",
         column1="move_line_id",
         column2="partial_reconcile_id",
+        copy=False,
     )
 
 
@@ -74,4 +75,5 @@ class AccountPartialReconcile(models.Model):
         relation="account_partial_reconcile_account_move_line_rel",
         column1="partial_reconcile_id",
         column2="move_line_id",
+        copy=False,
     )


### PR DESCRIPTION
FWP from 13.0: https://github.com/OCA/account-payment/pull/525

partial_reconcile_returned_ids is kept when invoice is duplicated

@Tecnativa TT38126