### PR TITLE
[18.0][FIX] account_payment_promissory_note: Fix get invoice lines

### DIFF
--- a/account_payment_promissory_note/wizard/account_register_payments.py
+++ b/account_payment_promissory_note/wizard/account_register_payments.py
@@ -27,8 +27,7 @@ class AccountRegisterPayments(models.TransientModel):
     def _onchange_promissory_note(self):
         result = super()._onchange_promissory_note()
         if not self.date_due and self.promissory_note:
-            active_ids = self.env.context.get("active_ids")
-            invoice_lines = self.env["account.move.line"].browse(active_ids)
+            invoice_lines = self.line_ids
             same_partner = len(invoice_lines.move_id.partner_id) == 1
             if invoice_lines and self.group_payment and same_partner:
                 self.date_due = max(invoice_lines.move_id.mapped("invoice_date_due"))


### PR DESCRIPTION
active_ids in context can refer to either account.move or account.move.line, so it cannot be used blindy to browse move lines.
Use line_ids field from the wizard instead as it's set according to active_model from context in default_get.


Makes tests failing in #863 