### PR TITLE
[FIX] account_payment_promissory_note: fix flaky test

### DIFF
--- a/account_payment_promissory_note/README.rst
+++ b/account_payment_promissory_note/README.rst
@@ -73,6 +73,8 @@ Contributors
   - Carlos Roca
   - César A. Sánchez
 
+- Jairo Llopis (`Moduon <https://www.moduon.team/>`__)
+
 Maintainers
 -----------
 

--- a/account_payment_promissory_note/readme/CONTRIBUTORS.md
+++ b/account_payment_promissory_note/readme/CONTRIBUTORS.md
@@ -3,3 +3,4 @@
   - Alexandre Díaz
   - Carlos Roca
   - César A. Sánchez
+- Jairo Llopis ([Moduon](https://www.moduon.team/))

--- a/account_payment_promissory_note/static/description/index.html
+++ b/account_payment_promissory_note/static/description/index.html
@@ -421,6 +421,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>César A. Sánchez</li>
 </ul>
 </li>
+<li>Jairo Llopis (<a class="reference external" href="https://www.moduon.team/">Moduon</a>)</li>
 </ul>
 </div>
 <div class="section" id="maintainers">

--- a/account_payment_promissory_note/wizard/account_register_payments.py
+++ b/account_payment_promissory_note/wizard/account_register_payments.py
@@ -27,9 +27,7 @@ class AccountRegisterPayments(models.TransientModel):
     def _onchange_promissory_note(self):
         result = super()._onchange_promissory_note()
         if not self.date_due and self.promissory_note:
-            active_ids = self.env.context.get("active_ids")
-            invoice_lines = self.env["account.move.line"].browse(active_ids)
-            same_partner = len(invoice_lines.move_id.partner_id) == 1
-            if invoice_lines and self.group_payment and same_partner:
-                self.date_due = max(invoice_lines.move_id.mapped("invoice_date_due"))
+            same_partner = len(self.line_ids.move_id.partner_id) == 1
+            if self.line_ids and self.group_payment and same_partner:
+                self.date_due = max(self.line_ids.move_id.mapped("invoice_date_due"))
         return result


### PR DESCRIPTION
The onchange was not checking the `active_model` before browsing the `active_ids`.

At the end of the day, the upstream wizard already does all the checks and
fulfills the `line_ids` appropriately.

The flaky test was `test_3_due_date_propagation`, where the wizard was created
with active invoices, not active lines. Sometimes it worked when by chance the
id of lines somehow matched the id of the invoice. But it was flaky nevertheless.

@moduon MT-10470
