### PR TITLE
[16.0][FIX] account_cash_invoice: Journal selectable

### DIFF
--- a/account_cash_invoice/tests/test_pay_invoice.py
+++ b/account_cash_invoice/tests/test_pay_invoice.py
@@ -82,24 +82,19 @@ class TestSessionPayInvoice(BaseCommon):
         )
 
     def test_bank_statement(self):
-        invoice_in_obj = self.env["cash.pay.invoice"].with_context(
-            active_ids=self.journal.ids, active_model=self.journal._name
-        )
+        invoice_in_obj = self.env["cash.pay.invoice"]
         with Form(invoice_in_obj) as in_invoice:
+            in_invoice.journal_id = self.journal
             in_invoice.invoice_type = "vendor"
             in_invoice.invoice_id = self.invoice_in
             self.assertEqual(-100, in_invoice.amount)
-            self.assertEqual(in_invoice.journal_id, self.journal)
         invoice_in_obj.browse(in_invoice.id).action_pay_invoice()
-
-        invoice_out_obj = self.env["cash.pay.invoice"].with_context(
-            active_ids=self.journal.ids, active_model=self.journal._name
-        )
+        invoice_out_obj = self.env["cash.pay.invoice"]
         with Form(invoice_out_obj) as out_invoice:
+            out_invoice.journal_id = self.journal
             out_invoice.invoice_type = "customer"
             out_invoice.invoice_id = self.invoice_out
             self.assertEqual(100, out_invoice.amount)
-            self.assertEqual(in_invoice.journal_id, self.journal)
         invoice_out_obj.browse(out_invoice.id).action_pay_invoice()
         inv_lines = self.invoice_in.line_ids.filtered(
             lambda line: line.account_id.account_type

--- a/account_cash_invoice/wizard/cash_pay_invoice.py
+++ b/account_cash_invoice/wizard/cash_pay_invoice.py
@@ -14,16 +14,6 @@ class CashPayInvoice(models.TransientModel):
     _name = "cash.pay.invoice"
     _description = "Cash Pay invoice from bank statement"
 
-    def _default_company(self):
-        active_ids = self.env.context.get("active_ids")
-        journal = self.env["account.journal"].browse(active_ids)
-        return journal.company_id
-
-    def _default_currency(self):
-        active_ids = self.env.context.get("active_ids")
-        journal = self.env["account.journal"].browse(active_ids)
-        return journal.currency_id or journal.company_id.currency_id
-
     invoice_id = fields.Many2one(
         comodel_name="account.move",
         string="Invoice",
@@ -34,22 +24,15 @@ class CashPayInvoice(models.TransientModel):
     )
     name = fields.Char(related="invoice_id.name", readonly=True)
     company_id = fields.Many2one(
-        comodel_name="res.company",
-        default=lambda self: self._default_company(),
-        required=True,
-        readonly=True,
+        comodel_name="res.company", compute="_compute_company_id"
     )
     currency_id = fields.Many2one(
-        comodel_name="res.currency",
-        default=lambda self: self._default_currency(),
-        required=True,
-        readonly=True,
+        comodel_name="res.currency", compute="_compute_currency_id"
     )
     journal_id = fields.Many2one(
         comodel_name="account.journal",
         required=True,
-        readonly=True,
-        default=lambda self: self.env.context.get("active_ids")[0],
+        domain="[('type', 'in', ['bank', 'cash'])]",
         string="Journal",
     )
     amount = fields.Monetary(compute="_compute_amount", store=True, readonly=False)
@@ -60,6 +43,17 @@ class CashPayInvoice(models.TransientModel):
         ],
     )
     invoice_domain = fields.Binary(compute="_compute_invoice_domain")
+
+    @api.depends("journal_id")
+    def _compute_company_id(self):
+        for record in self:
+            record.company_id = record.journal_id.company_id
+
+    @api.depends("journal_id")
+    def _compute_currency_id(self):
+        for record in self:
+            journal = record.journal_id
+            record.currency_id = journal.currency_id or journal.company_id.currency_id
 
     @api.depends("company_id", "currency_id", "invoice_type")
     def _compute_invoice_domain(self):


### PR DESCRIPTION
The journal where to pay should be selectable at user level, so the readonly flag is not correct.

Initializing also with the active_id is not correct, as you may come from other screens like PoS session.

Finally, the field should be restricted to proper journals, not all.

@Tecnativa TT57569