### PR TITLE
[17.0][FIX] account_payment_return: Missed reconciled aml without payment related

### DIFF
--- a/account_payment_return/models/account_move.py
+++ b/account_payment_return/models/account_move.py
@@ -66,14 +66,12 @@ class AccountMove(models.Model):
                     "move_id": move.id,
                     "title": _("Returned on"),
                 }
-                reconciled_payments = move._get_reconciled_payments()
                 domain = [("origin_returned_move_ids.move_id", "=", move.id)]
-                if len(reconciled_payments) > 0:
-                    for rec_payment in reconciled_payments:
-                        vals_rec_payment = self.prepare_values_returned_widget(
-                            rec_payment, rec_payment.amount
-                        )
-                        values_returned.append(vals_rec_payment)
+                for reconciled_aml in move._get_reconciled_amls():
+                    vals_rec_payment = self.prepare_values_returned_widget(
+                        reconciled_aml, -reconciled_aml.balance
+                    )
+                    values_returned.append(vals_rec_payment)
                 move_reconciles = self.env["account.partial.reconcile"].search(domain)
                 for move_reconcile in move_reconciles:
                     payment_ret = move_reconcile.debit_move_id
@@ -87,6 +85,10 @@ class AccountMove(models.Model):
                     )
                     values_returned.append(vals_reconcile)
                 if payments_widget_vals["content"]:
+                    payments_widget_vals["content"] = sorted(
+                        payments_widget_vals["content"],
+                        key=lambda x: (x["date"], x["partial_id"]),
+                    )
                     move.invoice_payments_widget = payments_widget_vals
                 else:
                     move.invoice_payments_widget = False


### PR DESCRIPTION
For example when an invoice is collected from the reconciliation of a bank statement.

@Tecnativa TT57767

ping @victoralmau @carlos-lopez-tecnativa