### PR TITLE
[18.0][IMP] account_payment_return: notify invoice of a payment return

### DIFF
--- a/account_payment_return/models/account_move.py
+++ b/account_payment_return/models/account_move.py
@@ -15,6 +15,11 @@ class AccountMove(models.Model):
         copy=False,
     )
 
+    def _payment_returned(self, return_line):
+        vals = return_line._prepare_invoice_returned_vals()
+        if vals:
+            self.write(vals)
+
     def check_payment_return(self):
         returned_invoices = (
             self.env["account.partial.reconcile"]
@@ -129,6 +134,9 @@ class AccountMoveLine(models.Model):
         column2="partial_reconcile_id",
         copy=False,
     )
+
+    def _payment_returned(self, return_line):
+        self.mapped("move_id")._payment_returned(return_line)
 
 
 class AccountPartialReconcile(models.Model):

--- a/account_payment_return/models/payment_return.py
+++ b/account_payment_return/models/payment_return.py
@@ -192,6 +192,7 @@ class PaymentReturn(models.Model):
                 # payment_aml: credit on customer account (from payment move)
                 # invoice_amls: debit on customer account (from invoice move)
                 invoice_amls = payment_aml.matched_debit_ids.mapped("debit_move_id")
+                invoice_amls._payment_returned(return_line)
                 all_move_lines |= payment_aml
                 invoices |= invoice_amls.mapped("move_id")
                 payment_aml.remove_move_reconcile()
@@ -224,7 +225,6 @@ class PaymentReturn(models.Model):
                     ]
                 }
             )
-        invoices.write(self._prepare_invoice_returned_vals())
         self.write({"state": "done", "move_id": move.id})
         return True
 
@@ -406,6 +406,10 @@ class PaymentReturnLine(models.Model):
             "journal_id": self.return_id.journal_id.id,
             "move_id": move.id,
         }
+
+    def _prepare_invoice_returned_vals(self):
+        res = self.return_id._prepare_invoice_returned_vals()
+        return res
 
     def _prepare_expense_lines_vals(self, move):
         self.ensure_one()


### PR DESCRIPTION
Migration of #310 : for better extensibility, notify the invoice that a payment return has arrived and let it do what it implies for itself.