### PR TITLE
[18.0][FIX] account_payment_return_import_iso20022: payment return match by payment id

### DIFF
--- a/account_payment_return_import_iso20022/models/payment_return.py
+++ b/account_payment_return_import_iso20022/models/payment_return.py
@@ -14,18 +14,17 @@ class PaymentReturnLine(models.Model):
         for line in self.filtered(lambda x: not x.move_line_ids and x.reference):
             if not line.reference.isdigit():
                 continue
-            payments = self.env["account.payment"].search(
+            payment = self.env["account.payment"].search(
                 [
-                    ("move_id", "=", int(line.reference)),
+                    ("id", "=", int(line.reference)),
                     ("payment_order_id", "!=", False),
                 ],
             )
-            if payments:
-                line.partner_id = payments[0].partner_id
-                for payment in payments:
-                    line.move_line_ids |= payment.move_id.line_ids.filtered(
-                        lambda x, payment=payment: x.account_id
-                        == payment.destination_account_id
-                        and x.partner_id == payment.partner_id
-                    )
+            if payment:
+                line.partner_id = payment.partner_id
+                line.move_line_ids |= payment.move_id.line_ids.filtered(
+                    lambda x, payment=payment: x.account_id
+                    == payment.destination_account_id
+                    and x.partner_id == payment.partner_id
+                )
         return super()._find_match()


### PR DESCRIPTION
Draft PR to open a discussion.
From my understanding and functional tests, the `payment_id` and not the `move_id` is passed as the End2end_identification from the generation of the payment order to the reception of the return.

I don't understand how can we expect to receive the `move_id` as the line `reference`. Is this a mistake or can someone explain this mechanism to me ?