### PR TITLE
[18.0][FIX] account_payment_return_import_iso20022: Amount is not computed when match by payment reference

### DIFF
--- a/account_payment_return_import_iso20022/models/payment_return.py
+++ b/account_payment_return_import_iso20022/models/payment_return.py
@@ -11,23 +11,21 @@ class PaymentReturnLine(models.Model):
 
     def _find_match(self):
         """Include in the matches the lines coming from payment orders."""
-        matched = self.env["payment.return.line"]
-        # noqa B023
         for line in self.filtered(lambda x: not x.move_line_ids and x.reference):
-            move_id = int(line.reference) if line.reference.isdigit() else -1
+            if not line.reference.isdigit():
+                continue
             payments = self.env["account.payment"].search(
                 [
-                    ("move_id", "=", move_id),
+                    ("move_id", "=", int(line.reference)),
                     ("payment_order_id", "!=", False),
                 ],
             )
             if payments:
                 line.partner_id = payments[0].partner_id
-                matched += line
                 for payment in payments:
                     line.move_line_ids |= payment.move_id.line_ids.filtered(
                         lambda x, payment=payment: x.account_id
                         == payment.destination_account_id
                         and x.partner_id == payment.partner_id
                     )
-        return super(PaymentReturnLine, self - matched)._find_match()
+        return super()._find_match()


### PR DESCRIPTION
Forward-port of #764 

This commit call supper method without processed lines in self: https://github.com/OCA/account-payment/commit/cd89ad977665da8d005549ffcf899fc2758a3388 and that proceed lines are not computed here:
https://github.com/OCA/account-payment/blob/f6f205acd14a474074e4cd301dad8ed426bcd15c/account_payment_return/models/payment_return.py#L393

@Tecnativa TT58268