### PR TITLE
[18.0][FIX] account_payment_return: Select proper outstanding account

### DIFF
--- a/account_payment_return/models/payment_return.py
+++ b/account_payment_return/models/payment_return.py
@@ -153,12 +153,13 @@ class PaymentReturn(models.Model):
 
     def _prepare_move_line(self, move, total_amount):
         self.ensure_one()
-        account = (
-            self.payment_method_line_id.payment_account_id
-            or self.journal_id.default_account_id
-        )
+        account = self.payment_method_line_id.payment_account_id
         if not account:
-            raise UserError(_("No account found on the payment method or journal."))
+            account = (
+                self.env["account.payment"]
+                .with_company(self.company_id)
+                ._get_outstanding_account("inbound")
+            )
         return {
             "name": move.ref,
             "debit": 0.0,


### PR DESCRIPTION
Odoo has changed the mechanism of selecting outstanding account: on v17 there were a field "account_journal_payment_debit_account_id" on res.company for holding the outstanding account. Now, this outstanding account is reflected through an XML-ID identifier.

Thus, the adaptation to the module should follow the same mechanism for selecting the outstanding account.

There's also no need of a specific error message, as the method already contains one.

@Tecnativa TT58856