### PR TITLE
[17.0][FIX]account_payment_term_extension: fix form view header

### DIFF
--- a/account_payment_term_extension/views/account_payment_term.xml
+++ b/account_payment_term_extension/views/account_payment_term.xml
@@ -16,9 +16,9 @@
         <field name="model">account.payment.term</field>
         <field name="inherit_id" ref="account.view_payment_term_form" />
         <field name="arch" type="xml">
-            <field name="company_id" position="after">
+            <xpath expr="//label[@for='early_discount']" position="before">
                 <field name="sequential_lines" />
-            </field>
+            </xpath>
             <data>
                 <xpath expr="//sheet" position="inside">
                     <separator string="Holidays" col="12" />


### PR DESCRIPTION
Fix form view header

**before the change**

<img width="1609" height="890" alt="image" src="https://github.com/user-attachments/assets/d2b3a6fa-70b4-4614-840a-4f68565a6247" />

**after the change**

<img width="1672" height="882" alt="image" src="https://github.com/user-attachments/assets/c4e6dd3e-0e39-49e1-8069-953f4e888686" />

cc @ForgeFlow