### PR TITLE
[17.0][FIX] account_payment_term_extension: Display correct amounts in jour…

### DIFF
--- a/account_payment_term_extension/models/account_payment_term.py
+++ b/account_payment_term_extension/models/account_payment_term.py
@@ -183,12 +183,14 @@ class AccountPaymentTerm(models.Model):
             else:
                 # Percentage amounts
                 line_amount = line.compute_line_amount(
-                    total_amount, remaining_amount, precision_digits
-                )
-                company_line_amount = line.compute_line_amount(
                     total_amount_currency,
                     remaining_amount_currency,
                     company_precision_digits,
+                )
+                company_line_amount = line.compute_line_amount(
+                    total_amount,
+                    remaining_amount,
+                    precision_digits,
                 )
                 term_vals["company_amount"] = company_line_amount
                 term_vals["foreign_amount"] = line_amount

--- a/account_payment_term_extension/tests/test_payment_term.py
+++ b/account_payment_term_extension/tests/test_payment_term.py
@@ -285,3 +285,57 @@ class TestAccountPaymentTerm(TransactionCase):
             self.account_payment_term_holiday.create(
                 {"holiday": "2015-06-07", "date_postponed": "2015-06-08"}
             )
+
+    def test_regression_multicurrency(self):
+        usd = self.env.ref("base.USD")
+        self.env["res.currency.rate"].create(
+            {
+                "name": "2025-01-01",
+                "rate": 2.0,
+                "currency_id": usd.id,
+                "company_id": self.company.id,
+            }
+        )
+        pay_term_50 = self.account_payment_term.create(
+            {
+                "name": "Test 50/50",
+                "line_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "value": "percent",
+                            "value_amount": 50.0,
+                            "nb_days": 0,
+                            "delay_type": "days_after",
+                        },
+                    ),
+                    (
+                        0,
+                        0,
+                        {
+                            "value": "percent",
+                            "value_amount": 50.0,
+                            "nb_days": 30,
+                            "delay_type": "days_after",
+                        },
+                    ),
+                ],
+            }
+        )
+        res = pay_term_50._compute_terms(
+            currency=usd,
+            company=self.company,
+            date_ref="2025-01-01",
+            tax_amount=0,
+            tax_amount_currency=0,
+            sign=1,
+            untaxed_amount=50.0,
+            untaxed_amount_currency=100.0,
+        )
+        linea_resultado = res["line_ids"][0]
+        self.assertEqual(
+            linea_resultado["company_amount"],
+            25.0,
+            "Error: The amount in Eur did not respect the exchange rate.",
+        )


### PR DESCRIPTION
When we create an invoice with an amount of $500 with payment terms with multiple terms, the journal items (30, 60 y 90 days) are created with euros in the column that should be dollars.

![image](https://github.com/user-attachments/assets/79053949-9934-487f-bb31-f7150fb4120d)

Currently, this info is displayed as:

![image](https://github.com/user-attachments/assets/852ef39c-50c1-4a2f-b7a6-6b7b485a3705)


As you can see, it does not make sense for euros to be a higher amount than dollars.