### PR TITLE
[18.0][FIX] account_payment: prevent filtering valid write-off lines with balance only

### DIFF
--- a/account_payment_line/models/account_payment.py
+++ b/account_payment_line/models/account_payment.py
@@ -117,11 +117,16 @@ class AccountPayment(models.Model):
         vals_list = super()._prepare_move_line_default_vals(
             write_off_line_vals=new_write_off_line_vals, force_balance=force_balance
         )
-        # filter line with both debit and credit equal 0
+
+        # filter line with debit, credit and balance equal 0
         filter_vals_list = [
             vals
             for vals in vals_list
-            if not (vals["debit"] == 0.0 and vals["credit"] == 0.0)
+            if not (
+                vals.get("debit", 0.0) == 0.0
+                and vals.get("credit", 0.0) == 0.0
+                and vals.get("balance", 0.0) == 0.0
+            )
         ]
         return filter_vals_list if filter_vals_list else vals_list
 


### PR DESCRIPTION
Problem: In `_prepare_move_line_default_vals`, there is a filter designed to remove empty move lines (where both debit and credit are 0). However, upstream code sometimes generates write-off lines containing only a balance key ([see](https://github.com/odoo/odoo/blob/3056facc07024d02829bf2e27c9ee2f56695c99e/addons/account/models/account_payment.py#L992-L998)), missing explicit debit or credit keys. In such cases, `vals['debit']`  and `vals['credit']` returns 0.0, causing the filter to incorrectly identify these valid lines as empty and drop them or raising an error:

```
File ".../account_payment_line/models/account_payment.py", line 130, in _prepare_move_line_default_vals
    if not (vals["debit"] == 0.0 and vals["credit"] == 0.0)
KeyError: 'debit'
```

Solution: Update the filtering condition to include the balance key. A line is now considered empty and removed only if debit, credit, AND balance are all zero. This approach preserves valid write-off lines (which have a non-zero balance) without needing to mutate the input vals_list.
