### PR TITLE
[18.0][FIX] account_payment_line: Adapt the code to prevent error 

### DIFF
--- a/account_payment_line/models/account_payment.py
+++ b/account_payment_line/models/account_payment.py
@@ -118,11 +118,7 @@ class AccountPayment(models.Model):
             write_off_line_vals=new_write_off_line_vals, force_balance=force_balance
         )
         # filter line with both debit and credit equal 0
-        filter_vals_list = [
-            vals
-            for vals in vals_list
-            if not (vals["debit"] == 0.0 and vals["credit"] == 0.0)
-        ]
+        filter_vals_list = [vals for vals in vals_list if vals["balance"] != 0.0]
         return filter_vals_list if filter_vals_list else vals_list
 
     def _prepare_move_line_counterpart_vals(self, write_off_line_vals=None):


### PR DESCRIPTION
Odoo now returns the `balance` instead of `credit` and `debit`. https://github.com/odoo/odoo/commit/531b887aec92c2fbf57495992be9fbc32d9ea20e

<img width="1072" height="287" alt="image" src="https://github.com/user-attachments/assets/75fadea0-b946-4813-b5b9-2b971b21d2de" />
@pedrobaeza could you please review this?