### PR TITLE
[18.0][FIX] account_due_list: deprecated invisible attr in payment_view

### DIFF
--- a/account_due_list/views/payment_view.xml
+++ b/account_due_list/views/payment_view.xml
@@ -64,7 +64,6 @@
                 <field name="date_maturity" optional="show" />
                 <field name="reconciled" readonly="1" optional="hide" />
                 <field name="full_reconcile_id" readonly="1" optional="hide" />
-                <field name="parent_state" invisible="1" />
             </list>
         </field>
     </record>


### PR DESCRIPTION
Removed the `parent_state` field declaration from `view_payments_tree`, as Odoo 18 auto-populates fields used in `decoration-*` expressions without needing an explicit declaration.


@Tecnativa TT62027
@pedrobaeza @carlosdauden 