### PR TITLE
[18.0][FIX] account_payment_line: update payment state assertions

### DIFF
--- a/account_payment_line/tests/test_account_payment_line.py
+++ b/account_payment_line/tests/test_account_payment_line.py
@@ -270,7 +270,7 @@ class TestAccountPaymentLines(AccountTestInvoicingCommon):
             [{"move_id": new_invoice}],
             post=True,
         )
-        self.assertEqual(new_payment.state, "in_process")
+        self.assertIn(new_payment.state, ["in_process", "paid"])
         self.assertTrue(new_payment.is_reconciled)
         self.assertEqual(new_payment.reconciled_bill_ids, new_invoice)
 
@@ -303,7 +303,7 @@ class TestAccountPaymentLines(AccountTestInvoicingCommon):
             [{"move_id": new_invoice2}],
             post=True,
         )
-        self.assertEqual(new_payment3.state, "in_process")
+        self.assertIn(new_payment3.state, ["in_process", "paid"])
         self.assertTrue(new_payment3.is_reconciled)
         self.assertEqual(new_payment3.reconciled_bill_ids, new_invoice2)
         self.assertEqual(new_invoice2.amount_residual, 0.0)
@@ -335,7 +335,7 @@ class TestAccountPaymentLines(AccountTestInvoicingCommon):
             ],
             post=True,
         )
-        self.assertEqual(new_payment.state, "in_process")
+        self.assertIn(new_payment.state, ["in_process", "paid"])
         self.assertTrue(new_payment.is_reconciled)
         self.assertEqual(new_payment.reconciled_bill_ids, new_invoice + new_invoice2)
         self.assertIn(new_invoice.payment_state, ["paid", "in_payment"])
@@ -353,7 +353,7 @@ class TestAccountPaymentLines(AccountTestInvoicingCommon):
             [{"move_id": new_refund}],
             post=True,
         )
-        self.assertEqual(new_payment_refund.state, "in_process")
+        self.assertIn(new_payment_refund.state, ["in_process", "paid"])
         self.assertTrue(new_payment_refund.is_reconciled)
         self.assertEqual(new_payment_refund.reconciled_bill_ids, new_refund)
         self.assertIn(new_refund.payment_state, ["paid", "in_payment"])


### PR DESCRIPTION
Update `test_03` and `test_04` assertions from `assertEqual(state, "in_process")` to `assertIn(state, ["in_process", "paid"])`, as in 18 version the resulting state depends on the journal configuration — whether an outstanding payments account is used or not.

@Tecnativa TT62027
@pedrobaeza @christian-ramos-tecnativa 