### PR TITLE
[18.0][FIX] account_payment_term_extension: fix percentage calculation with fixed amount on first line

### DIFF
--- a/account_payment_term_extension/models/account_payment_term.py
+++ b/account_payment_term_extension/models/account_payment_term.py
@@ -183,12 +183,13 @@ class AccountPaymentTerm(models.Model):
                 term_vals["company_amount"] = company_line_amount
                 term_vals["foreign_amount"] = line_amount
             else:
-                # Percentage amounts
+                # Percentage amounts - use remaining_amount for correct calculation
+                # when there are fixed amounts on previous lines
                 line_amount = line.compute_line_amount(
-                    total_amount, remaining_amount, precision_digits
+                    remaining_amount, remaining_amount, precision_digits
                 )
                 company_line_amount = line.compute_line_amount(
-                    total_amount_currency,
+                    remaining_amount_currency,
                     remaining_amount_currency,
                     company_precision_digits,
                 )

--- a/account_payment_term_extension/models/account_payment_term_line.py
+++ b/account_payment_term_extension/models/account_payment_term_line.py
@@ -150,7 +150,8 @@ class AccountPaymentTermLine(models.Model):
         if self.value == "fixed":
             return float_round(self.value_amount, precision_digits=precision_digits)
         elif self.value in ("percent", "percent_amount_untaxed"):
-            amt = total_amount * self.value_amount / 100.0
+            # Use remaining_amount to correctly handle fixed amounts on previous lines
+            amt = remaining_amount * self.value_amount / 100.0
             if self.amount_round:
                 amt = float_round(amt, precision_rounding=self.amount_round)
             return float_round(amt, precision_digits=precision_digits)


### PR DESCRIPTION
## Description

When a payment term has a fixed amount on the first line and percentage lines after it, the percentage lines are calculated on the full invoice total instead of the remaining amount after deducting the fixed amount.

This causes incorrect amounts and in some cases negative amounts on the last payment term line.

## Steps to reproduce

1. Create a payment term with:
   - Line 1: Fixed amount = 400€, Due immediately (0 days)
   - Line 2: 33% at 30 days
   - Line 3: 33% at 60 days
   - Line 4: 34% at 90 days

2. Create an invoice for 1000€ with this payment term

**Expected:**
- 400€ at day 0 (fixed)
- 198€ at 30 days (33% of 600€)
- 198€ at 60 days (33% of 600€)
- 204€ at 90 days (34% of 600€)

**Actual (bug):**
- 400€ at day 0
- 330€ at 30 days (33% of 1000€)
- 330€ at 60 days (33% of 1000€)
- -60€ at 90 days (negative!)

## Fix

Changed  in both  and  to use  instead of  for percentage calculations. This ensures that percentage lines are calculated on the residual amount after fixed amounts have been deducted.

## Related Issue

Closes https://github.com/OCA/account-payment/issues/924

---

Contributor from SMWLAB community. First OCA PR!