### PR TITLE
[18.0][FIX] account_payment_return: Retrieving the correct value for outstanding_account

### DIFF
--- a/account_payment_return/models/payment_return.py
+++ b/account_payment_return/models/payment_return.py
@@ -155,11 +155,8 @@ class PaymentReturn(models.Model):
         self.ensure_one()
         account = self.payment_method_line_id.payment_account_id
         if not account:
-            account = (
-                self.env["account.payment"]
-                .with_company(self.company_id)
-                ._get_outstanding_account("inbound")
-            )
+            payment = self.env["account.payment"].with_company(self.company_id).new()
+            account = payment._get_outstanding_account("inbound")
         return {
             "name": move.ref,
             "debit": 0.0,


### PR DESCRIPTION
Retrieving the correct value for outstanding_account

In a multi-company environment, you must call the `_get_outstanding_account()` method with a virtual `account.payment` record to ensure that the value returned corresponds to the correct company.

Please @pedrobaeza and @carlos-lopez-tecnativa can you review it?

@Tecnativa TT62403