### PR TITLE
[18.0][FIX] account_payment_promissory_note: setup batch payment sequence in tests.

### DIFF
--- a/account_payment_promissory_note/tests/test_account_payment_promissory_note.py
+++ b/account_payment_promissory_note/tests/test_account_payment_promissory_note.py
@@ -18,6 +18,23 @@ class TestAccountPaymentPromissoryNote(TransactionCase):
             self.default_journal_cash.inbound_payment_method_line_ids[0]
         )
         self.company = self.env.ref("base.main_company")
+        if not self.company.batch_payment_sequence_id:
+            # Odoo 18 computes the payment communication when initializing the
+            # register payment wizard, and grouped payments need this sequence.
+            self.company.sudo().batch_payment_sequence_id = (
+                self.env["ir.sequence"]
+                .sudo()
+                .create(
+                    {
+                        "name": "Batch Payment Number Sequence",
+                        "implementation": "no_gap",
+                        "padding": 5,
+                        "use_date_range": True,
+                        "company_id": self.company.id,
+                        "prefix": "BATCH/%(range_year)s/",
+                    }
+                )
+            )
         partner = self.env.ref("base.partner_demo")
         self.invoice_1 = self.env["account.move"].create(
             {


### PR DESCRIPTION
### Description

This PR fixes the tests of account_payment_promissory_note on Odoo 18.

When account.payment.register is initialized through Form, Odoo computes the payment communication. For grouped payments, that computation calls company.batch_payment_sequence_id.next_by_id().

In some test databases, base.main_company already exists without batch_payment_sequence_id, so the wizard initialization crashes before the module-specific assertions are reached.

This PR ensures the test company has the required batch payment sequence during test setup.

### Steps to reproduce:

invoke test -m account_payment_promissory_note

Before this fix, tests test_2_onchange_promissory_note_with_invoices and test_3_due_date_propagation fail with:

SELECT number_next FROM ir_sequence WHERE id=false FOR UPDATE NOWAIT
psycopg2.errors.UndefinedFunction: operator does not exist: integer = boolean

### Result:

The module tests pass with 0 failed and 0 errors.

cc @Tecnativa 

ping @carlosdauden @CarlosRoca13 @carlos-lopez-tecnativa 